### PR TITLE
First pass at debranding the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# Puppet
+# OpenVox
 
-![RSpec tests](https://github.com/puppetlabs/puppet/workflows/RSpec%20tests/badge.svg)
-[![Gem Version](https://badge.fury.io/rb/puppet.svg)](https://badge.fury.io/rb/puppet)
-[![Inline docs](https://inch-ci.org/github/puppetlabs/puppet.svg)](https://inch-ci.org/github/puppetlabs/puppet)
-
-Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs
+OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs
 administrative tasks (such as adding users, installing packages, and updating server
 configurations) based on a centralized specification.
 
@@ -19,14 +15,10 @@ Documentation for Puppet and related projects can be found online at the
 
 ## Installation
 
-The best way to run Puppet is with [Puppet Enterprise (PE)](https://puppet.com/products/puppet-enterprise/),
-which also includes orchestration features, a web console, and professional support.
-The PE documentation is [available here.](https://puppet.com/docs/pe/latest)
+To install OpenVox,
+[see our installation guide.](https://voxpupuli.org/openvox/install/) and [quickstart page](https://voxpupuli.org/openvox/quickstart/).
 
-To install an open source release of Puppet,
-[see the installation guide on the docs site.](https://puppet.com/docs/puppet/latest/installing_and_upgrading.html)
-
-If you need to run Puppet from source as a tester or developer,
+If you need to run OpenVox from source as a tester or developer,
 see the [Quick Start to Developing on Puppet](docs/quickstart.md) guide.
 
 ## Developing and Contributing
@@ -34,7 +26,7 @@ see the [Quick Start to Developing on Puppet](docs/quickstart.md) guide.
 We'd love to get contributions from you! For a quick guide to getting your
 system setup for developing, take a look at our [Quickstart
 Guide](https://github.com/puppetlabs/puppet/blob/main/docs/quickstart.md). Once you are up and running, take a look at the
-[Contribution Documents](https://github.com/puppetlabs/.github/blob/main/CONTRIBUTING.md) to see how to get your changes merged
+[Contribution Documents](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) to see how to get your changes merged
 in.
 
 For more complete docs on developing with Puppet, take a look at the
@@ -42,13 +34,18 @@ rest of the [developer documents](https://github.com/puppetlabs/puppet/blob/main
 
 ## Licensing
 
-See [LICENSE](https://github.com/puppetlabs/puppet/blob/main/LICENSE) file. Puppet is licensed by Puppet, Inc. under the Apache license. Puppet, Inc. can be contacted at: info@puppet.com
+See [LICENSE](https://github.com/puppetlabs/puppet/blob/main/LICENSE) file. OpenVox is licensed by Vox Pupuli as a community maintained
+implementation of Puppet. Vox Pupuli can be contacted at: pmc@voxpupuli.org.
+Puppet itself is licensed by Puppet, Inc. under the Apache license. Puppet, Inc. can be contacted at: info@puppet.com
 
 ## Support
 
-Please log issues in this project's [GitHub Issues](https://github.com/puppetlabs/puppet/issues). A [mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
-available for asking questions and getting help from others, or if you prefer chat, we also have a [Puppet Community slack.](https://puppetcommunity.slack.com/)
+Please log issues in this project's [GitHub Issues](/issues).
+Other channels for getting help can be found at our
+[support page](https://voxpupuli.org/openvox/support/),
+including the mailing list and other community spaces available
+for asking questions and getting help from others.
+
 
 We use semantic version numbers for our releases and recommend that users stay
 as up-to-date as possible by upgrading to patch releases and minor releases as
@@ -61,8 +58,3 @@ a best-effort basis, until the previous major version is no longer maintained.
 For example: If a security vulnerability is discovered in Puppet 8.1.1, we
 would fix it in the 8 series, most likely as 8.1.2. Maintainers would then make
 a best effort to backport that fix onto the latest Puppet 7 release.
-
-Long-term support, including security patches and bug fixes, is available for
-commercial customers. Please see the following page for more details:
-
-[Puppet Enterprise Support Lifecycle](https://puppet.com/docs/puppet-enterprise/product-support-lifecycle/)

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -5,7 +5,7 @@ require_relative 'puppet/concurrent/synchronized'
 
 Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '3.1.0'
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
-  raise LoadError, "Puppet #{Puppet.version} requires Ruby #{Puppet::OLDEST_RECOMMENDED_RUBY_VERSION} or greater, found Ruby #{RUBY_VERSION.dup}."
+  raise LoadError, "OpenVox #{Puppet.version} requires Ruby #{Puppet::OLDEST_RECOMMENDED_RUBY_VERSION} or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
 $LOAD_PATH.extend(Puppet::Concurrent::Synchronized)

--- a/lib/puppet/agent/disabler.rb
+++ b/lib/puppet/agent/disabler.rb
@@ -18,14 +18,14 @@ module Puppet::Agent::Disabler
 
   # Let the daemon run again, freely in the filesystem.
   def enable
-    Puppet.notice _("Enabling Puppet.")
+    Puppet.notice _("Enabling OpenVox.")
     disable_lockfile.unlock
   end
 
   # Stop the daemon from making any catalog runs.
   def disable(msg = nil)
     data = {}
-    Puppet.notice _("Disabling Puppet.")
+    Puppet.notice _("Disabling OpenVox.")
     unless msg.nil?
       data[DISABLED_MESSAGE_JSON_KEY] = msg
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -20,7 +20,7 @@ class Puppet::Configurer
 
   # Provide more helpful strings to the logging that the Agent does
   def self.to_s
-    _("Puppet configuration client")
+    _("OpenVox configuration client")
   end
 
   def self.should_pluginsync?
@@ -317,7 +317,7 @@ class Puppet::Configurer
       if options[:catalog].nil? && do_failover
         server, port = find_functional_server
         if server.nil?
-          detail = _("Could not select a functional puppet server from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
+          detail = _("Could not select a functional server from server_list: '%{server_list}'") % { server_list: Puppet.settings.value(:server_list, Puppet[:environment].to_sym, true) }
           if Puppet[:usecacheonfailure]
             options[:pluginsync] = false
             @running_failure = true
@@ -331,7 +331,7 @@ class Puppet::Configurer
           end
         else
           # TRANSLATORS 'server_list' is the name of a setting and should not be translated
-          Puppet.debug _("Selected puppet server from the `server_list` setting: %{server}:%{port}") % { server: server, port: port }
+          Puppet.debug _("Selected server from the `server_list` setting: %{server}:%{port}") % { server: server, port: port }
           report.server_used = "#{server}:#{port}"
         end
         Puppet.override(server: server, serverport: port) do

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -74,18 +74,18 @@ module Puppet
     :confdir  => {
         :default  => nil,
         :type     => :directory,
-        :desc     => "The main Puppet configuration directory.  The default for this setting
+        :desc     => "The main OpenVox configuration directory.  The default for this setting
           is calculated based on the user.  If the process is running as root or
-          the user that Puppet is supposed to run as, it defaults to a system
+          the user that OpenVox is supposed to run as, it defaults to a system
           directory, but if it's running as any other user, it defaults to being
           in the user's home directory.",
     },
     :codedir  => {
         :default  => nil,
         :type     => :directory,
-        :desc     => "The main Puppet code directory.  The default for this setting
+        :desc     => "The main OpenVox code directory.  The default for this setting
           is calculated based on the user.  If the process is running as root or
-          the user that Puppet is supposed to run as, it defaults to a system
+          the user that OpenVox is supposed to run as, it defaults to a system
           directory, but if it's running as any other user, it defaults to being
           in the user's home directory.",
     },
@@ -94,7 +94,7 @@ module Puppet
         :type     => :directory,
         :owner    => "service",
         :group    => "service",
-        :desc     => "Where Puppet stores dynamic and growing data.  The default for this
+        :desc     => "Where OpenVox stores dynamic and growing data.  The default for this
           setting is calculated specially, like `confdir`_.",
     },
 
@@ -120,7 +120,7 @@ module Puppet
       :default    => 'notice',
       :type       => :enum,
       :values     => %w[debug info notice warning err alert emerg crit],
-      :desc       => "Default logging level for messages from Puppet. Allowed values are:
+      :desc       => "Default logging level for messages from OpenVox. Allowed values are:
 
         * debug
         * info
@@ -138,10 +138,10 @@ module Puppet
       :default => [],
       :type    => :array,
       :desc    => "A comma-separated list of warning types to suppress. If large numbers
-        of warnings are making Puppet's logs too large or difficult to use, you
+        of warnings are making OpenVox's logs too large or difficult to use, you
         can temporarily silence them with this setting.
 
-        If you are preparing to upgrade Puppet to a new major version, you
+        If you are preparing to upgrade OpenVox to a new major version, you
         should re-enable all warnings for a while.
 
         Valid values for this setting are:
@@ -182,7 +182,7 @@ module Puppet
       :default    => :error,
       :type       => :symbolic_enum,
       :values     => [:off, :warning, :error],
-      :desc       => "The strictness level of puppet. Allowed values are:
+      :desc       => "The strictness level of OpenVox. Allowed values are:
 
         * off     - do not perform extra validation, do not report
         * warning - perform extra validation, report as warning
@@ -205,7 +205,7 @@ module Puppet
     :disable_i18n => {
       :default => true,
       :type    => :boolean,
-      :desc    => "If true, turns off all translations of Puppet and module
+      :desc    => "If true, turns off all translations of OpenVox and module
         log messages, which affects error, warning, and info log messages,
         as well as any translations in the report and CLI.",
       :hook    => proc do |value|
@@ -224,14 +224,14 @@ module Puppet
       :desc    => "The scheduling priority of the process.  Valid values are 'high',
         'normal', 'low', or 'idle', which are mapped to platform-specific
         values.  The priority can also be specified as an integer value and
-        will be passed as is, e.g. -5.  Puppet must be running as a privileged
+        will be passed as is, e.g. -5.  OpenVox must be running as a privileged
         user in order to increase scheduling priority.",
     },
     :trace => {
         :default  => false,
         :type     => :boolean,
         :desc     => "Whether to print stack traces on some errors. Will print
-          internal Ruby stack trace interleaved with Puppet function frames.",
+          internal Ruby stack trace interleaved with OpenVox function frames.",
         :hook     => proc do |value|
           # Enable or disable Facter's trace option too
           Puppet.runtime[:facter].trace(value)
@@ -240,7 +240,7 @@ module Puppet
     :puppet_trace => {
         :default  => false,
         :type     => :boolean,
-        :desc     => "Whether to print the Puppet stack trace on some errors.
+        :desc     => "Whether to print the OpenVox stack trace on some errors.
           This is a noop if `trace` is also set.",
     },
     :profile => {
@@ -259,7 +259,7 @@ module Puppet
       :default    => true,
       :type       => :boolean,
       :desc       => "Whether to compile a [static catalog](https://puppet.com/docs/puppet/latest/static_catalogs.html#enabling-or-disabling-static-catalogs),
-        which occurs only on Puppet Server when the `code-id-command` and
+        which occurs only on OpenVox Server when the `code-id-command` and
         `code-content-command` settings are configured in its `puppetserver.conf` file.",
     },
     :settings_catalog => {
@@ -289,7 +289,7 @@ module Puppet
         :default  => "$vardir/state",
         :type     => :directory,
         :mode     => "01755",
-        :desc     => "The directory where Puppet state is stored.  Generally,
+        :desc     => "The directory where OpenVox state is stored.  Generally,
           this directory can be removed without causing harm (although it
           might result in spurious service restarts)."
     },
@@ -299,12 +299,12 @@ module Puppet
       :mode     => "0755",
       :owner    => "service",
       :group    => "service",
-      :desc     => "Where Puppet PID files are kept."
+      :desc     => "Where OpenVox PID files are kept."
     },
     :genconfig => {
         :default  => false,
         :type     => :boolean,
-        :desc     => "When true, causes Puppet applications to print an example config file
+        :desc     => "When true, causes OpenVox applications to print an example config file
           to stdout and exit. The example will include descriptions of each
           setting, and the current (or default) value of each setting,
           incorporating any settings overridden on the CLI (with the exception
@@ -322,7 +322,7 @@ module Puppet
         :default    => "",
         :deprecated => :completely,
         :desc       => "Prints the value of a specific configuration setting.  If the name of a
-          setting is provided for this, then the value is printed and puppet
+          setting is provided for this, then the value is printed and the process
           exits.  Comma-separate multiple values.  For a list of all values,
           specify 'all'. This setting is deprecated, the 'puppet config' command replaces this functionality.",
     },
@@ -335,20 +335,19 @@ module Puppet
     :mkusers => {
         :default  => false,
         :type     => :boolean,
-        :desc     => "Whether to create the necessary user and group that puppet agent will run as.",
+        :desc     => "Whether to create the necessary user and group that the OpenVox agent will run as.",
     },
     :manage_internal_file_permissions => {
         :default  => ! Puppet::Util::Platform.windows?,
         :type     => :boolean,
-        :desc     => "Whether Puppet should manage the owner, group, and mode of files it uses internally.
+        :desc     => "Whether OpenVox should manage the owner, group, and mode of files it uses internally.
           **Note**: For Windows agents, the default is `false` for versions 4.10.13 and greater, versions 5.5.6 and greater, and versions 6.0 and greater.",
     },
     :onetime => {
         :default  => false,
         :type     => :boolean,
         :desc     => "Perform one configuration run and exit, rather than spawning a long-running
-          daemon. This is useful for interactively running puppet agent, or
-          running puppet agent from cron.",
+          daemon. This is useful for interactively running the OpenVox agent, or running it from cron.",
         :short    => 'o',
     },
     :path => {
@@ -374,18 +373,18 @@ module Puppet
     :libdir => {
         :type           => :directory,
         :default        => "$vardir/lib",
-        :desc           => "An extra search path for Puppet.  This is only useful
-          for those files that Puppet will load on demand, and is only
+        :desc           => "An extra search path for OpenVox.  This is only useful
+          for those files that OpenVox will load on demand, and is only
           guaranteed to work for those cases.  In fact, the autoload
           mechanism is responsible for making sure this directory
           is in Ruby's search path\n"
     },
     :environment => {
         :default  => "production",
-        :desc     => "The environment in which Puppet is running. For clients,
+        :desc     => "The environment in which OpenVox is running. For clients,
           such as `puppet agent`, this determines the environment itself, which
-          Puppet uses to find modules and much more. For servers, such as `puppet server`,
-          this provides the default environment for nodes that Puppet knows nothing about.
+          OpenVox uses to find modules and much more. For servers, such as `puppet server`,
+          this provides the default environment for nodes that OpenVox knows nothing about.
 
           When defining an environment in the `[agent]` section, this refers to the
           environment that the agent requests from the primary server. The environment doesn't
@@ -393,9 +392,9 @@ module Puppet
           primary server. This definition is used when running `puppet agent`.
 
           When defined in the `[user]` section, the environment refers to the path that
-          Puppet uses to search for code and modules related to its execution. This
-          requires the environment to exist locally on the filesystem where puppet is
-          being executed. Puppet subcommands, including `puppet module` and
+          OpenVox uses to search for code and modules related to its execution. This
+          requires the environment to exist locally on the filesystem where OpenVox is
+          being executed. OpenVox subcommands, including `puppet module` and
           `puppet apply`, use this definition.
 
           Given that the context and effects vary depending on the
@@ -419,7 +418,7 @@ module Puppet
       :default  => true,
       :desc     => <<-'EOT'
       Specifies how environment paths are reported. When the value of
-      `versioned_environment_dirs` is `true`, Puppet applies the readlink function to
+      `versioned_environment_dirs` is `true`, OpenVox applies the readlink function to
       the `environmentpath` setting when constructing the environment's modulepath. The
       full readlinked path is referred to as the "resolved path," and the configured
       path potentially containing symlinks is the "configured path." When reporting
@@ -433,7 +432,7 @@ module Puppet
       :type     => :boolean,
       :default  => true,
       :desc     => <<-'EOT'
-      Puppet saves both the initial and converged environment in the last_run_summary file.
+      OpenVox saves both the initial and converged environment in the last_run_summary file.
       If they differ, and this setting is set to true, we will use the last converged
       environment and skip the node request.
 
@@ -469,16 +468,16 @@ module Puppet
     :diff => {
       :default => (Puppet::Util::Platform.windows? ? "" : "diff"),
       :desc    => "Which diff command to use when printing differences between files. This setting
-          has no default value on Windows, as standard `diff` is not available, but Puppet can use many
+          has no default value on Windows, as standard `diff` is not available, but OpenVox can use many
           third-party diff tools.",
     },
     :show_diff => {
         :type     => :boolean,
         :default  => false,
         :desc     => "Whether to log and report a contextual diff when files are being replaced.
-          This causes partial file contents to pass through Puppet's normal
+          This causes partial file contents to pass through OpenVox's normal
           logging and reporting system, so this setting should be used with
-          caution if you are sending Puppet's reports to an insecure
+          caution if you are sending OpenVox's reports to an insecure
           destination. This feature currently requires the `diff/lcs` Ruby
           library.",
     },
@@ -486,7 +485,7 @@ module Puppet
         :type     => :boolean,
         :default  => !Puppet::Util::Platform.windows?,
         :desc     => "Whether to send the process into the background.  This defaults
-          to true on POSIX systems, and to false on Windows (where Puppet
+          to true on POSIX systems, and to false on Windows (where OpenVox
           currently cannot daemonize).",
         :short    => "D",
         :hook     => proc do |value|
@@ -514,13 +513,13 @@ module Puppet
       :desc       => <<-'EOT',
         Which node data plugin to use when compiling node catalogs.
 
-        When Puppet compiles a catalog, it combines two primary sources of info: the main manifest,
+        When OpenVox compiles a catalog, it combines two primary sources of info: the main manifest,
         and a node data plugin (often called a "node terminus," for historical reasons). Node data
         plugins provide three things for a given node name:
 
         1. A list of classes to add to that node's catalog (and, optionally, values for their
            parameters).
-        2. Which Puppet environment the node should use.
+        2. Which OpenVox environment the node should use.
         3. A list of additional top-scope variables to set.
 
         The three main node data plugins are:
@@ -574,12 +573,12 @@ module Puppet
         config = File.expand_path(File.join(settings[:confdir], 'hiera.yaml')) if config.nil?
         config
       end,
-      :desc    => "The hiera configuration file. Puppet only reads this file on startup, so you must restart the puppet server every time you edit it.",
+      :desc    => "The hiera configuration file. OpenVox only reads this file on startup, so you must restart the server every time you edit it.",
       :type    => :file,
     },
     :binder_config => {
       :default => nil,
-      :desc    => "The binder configuration file. Puppet reads this file on each request to configure the bindings system.
+      :desc    => "The binder configuration file. OpenVox reads this file on each request to configure the bindings system.
       If set to nil (the default), a $confdir/binder_config.yaml is optionally loaded. If it does not exists, a default configuration
       is used. If the setting :binding_config is specified, it must reference a valid and existing yaml file.",
       :type    => :file,
@@ -693,12 +692,12 @@ module Puppet
       :default    => "15s",
       :type       => :duration,
       :desc       => "The minimum time to wait between checking for updates in
-      configuration files.  This timeout determines how quickly Puppet checks whether
+      configuration files.  This timeout determines how quickly OpenVox checks whether
       a file (such as manifests or puppet.conf) has changed on disk. The default will
-      change in a future release to be 'unlimited', requiring a reload of the Puppet
+      change in a future release to be 'unlimited', requiring a reload of the OpenVox
       service to pick up changes to its internal configuration. Currently we do not
       accept a value of 'unlimited'. To reparse files within an environment in
-      Puppet Server please use the environment_cache endpoint",
+      OpenVox Server please use the environment_cache endpoint",
       :hook => proc do |val|
         unless [0, 15, '15s'].include?(val)
           Puppet.deprecation_warning(<<-WARNING)
@@ -713,21 +712,21 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
     :environment_timeout => {
       :default    => "0",
       :type       => :ttl,
-      :desc       => "How long the Puppet server should cache data it loads from an
+      :desc       => "How long the OpenVox server should cache data it loads from an
       environment.
 
       A value of `0` will disable caching. This setting can also be set to
       `unlimited`, which will cache environments until the server is restarted
-      or told to refresh the cache. All other values will result in Puppet
+      or told to refresh the cache. All other values will result in OpenVox
       server evicting environments that haven't been used within the last
       `environment_timeout` seconds.
 
-      You should change this setting once your Puppet deployment is doing
+      You should change this setting once your OpenVox deployment is doing
       non-trivial work. We chose the default value of `0` because it lets new
       users update their code without any extra steps, but it lowers the
-      performance of your Puppet server. We recommend either:
+      performance of your OpenVox server. We recommend either:
 
-      * Setting this to `unlimited` and explicitly refreshing your Puppet server
+      * Setting this to `unlimited` and explicitly refreshing your OpenVox server
         as part of your code deployment process.
 
       * Setting this to a number that will keep your most actively used
@@ -736,8 +735,8 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
         value.
 
       Once you set `environment_timeout` to a non-zero value, you need to tell
-      Puppet server to read new code from disk using the `environment-cache` API
-      endpoint after you deploy new code. See the docs for the Puppet Server
+      OpenVox server to read new code from disk using the `environment-cache` API
+      endpoint after you deploy new code. See the docs for the OpenVox Server
       [administrative API](https://puppet.com/docs/puppetserver/latest/admin-api/v1/environment-cache.html).
       "
     },
@@ -758,12 +757,12 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
     :prerun_command => {
       :default    => "",
       :desc       => "A command to run before every agent run.  If this command returns a non-zero
-      return code, the entire Puppet run will fail.",
+      return code, the entire OpenVox run will fail.",
     },
     :postrun_command => {
       :default    => "",
       :desc       => "A command to run after every agent run.  If this command returns a non-zero
-      return code, the entire Puppet run will be considered to have failed, even though it might have
+      return code, the entire OpenVox run will be considered to have failed, even though it might have
       performed work during the normal run.",
     },
     :freeze_main => {
@@ -784,8 +783,8 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
     :location_trusted => {
       :default => false,
       :type     => :boolean,
-      :desc    => "This will allow sending the name + password and the cookie header to all hosts that puppet may redirect to.
-        This may or may not introduce a security breach if puppet redirects you to a site to which you'll send your authentication info and cookies."
+      :desc    => "This will allow sending the name + password and the cookie header to all hosts that OpenVox may redirect to.
+        This may or may not introduce a security breach if OpenVox redirects you to a site to which you'll send your authentication info and cookies."
     }
   )
 
@@ -815,11 +814,11 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
     :certname => {
       :default => -> { Puppet::Settings.default_certname.downcase },
       :desc => "The name to use when handling certificates. When a node
-        requests a certificate from the CA Puppet Server, it uses the value of the
+        requests a certificate from the CA OpenVox Server, it uses the value of the
         `certname` setting as its requested Subject CN.
 
         This is the name used when managing a node's permissions in
-        Puppet Server's [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html).
+        OpenVox Server's [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html).
         In most cases, it is also used as the node's name when matching
         [node definitions](https://puppet.com/docs/puppet/latest/lang_node_definitions.html)
         and requesting data from an ENC. (This can be changed with the `node_name_value`
@@ -846,30 +845,30 @@ Valid values are 0 (never cache) and 15 (15 second minimum wait time).
     :dns_alt_names => {
       :default => '',
       :desc    => <<EOT,
-A comma-separated list of alternate DNS names for Puppet Server. These are extra
+A comma-separated list of alternate DNS names for your OpenVox Server. These are extra
 hostnames (in addition to its `certname`) that the server is allowed to use when
-serving agents. Puppet checks this setting when automatically creating a
-certificate for Puppet agent or Puppet Server. These can be either IP or DNS, and the type
+serving agents. OpenVox checks this setting when automatically creating a
+certificate for OpenVox agent or OpenVox Server. These can be either IP or DNS, and the type
 should be specified and followed with a colon. Untyped inputs will default to DNS.
 
 In order to handle agent requests at a given hostname (like
-"puppet.example.com"), Puppet Server needs a certificate that proves it's
+"openvox.example.com"), OpenVox Server needs a certificate that proves it's
 allowed to use that name; if a server shows a certificate that doesn't include
-its hostname, Puppet agents will refuse to trust it. If you use a single
-hostname for Puppet traffic but load-balance it to multiple Puppet Servers, each
+its hostname, OpenVox agents will refuse to trust it. If you use a single
+hostname for OpenVox traffic but load-balance it to multiple OpenVox Servers, each
 of those servers needs to include the official hostname in its list of extra
 names.
 
 **Note:** The list of alternate names is locked in when the server's
 certificate is signed. If you need to change the list later, you can't just
 change this setting; you also need to regenerate the certificate. For more
-information on that process, see the 
+information on that process, see the
 [cert regen docs](https://puppet.com/docs/puppet/latest/ssl_regenerate_certificates.html).
 
 To see all the alternate names your servers are using, log into your CA server
 and run `puppetserver ca list --all`, then check the output for `(alt names: ...)`.
 Most agent nodes should NOT have alternate names; the only certs that should
-have them are Puppet Server nodes that you want other agents to trust.
+have them are OpenVox Server nodes that you want other agents to trust.
 EOT
     },
     :csr_attributes => {
@@ -878,7 +877,7 @@ EOT
       :desc => <<EOT
 An optional file containing custom attributes to add to certificate signing
 requests (CSRs). You should ensure that this file does not exist on your CA
-Puppet Server; if it does, unwanted certificate extensions may leak into
+OpenVox Server; if it does, unwanted certificate extensions may leak into
 certificates created with the `puppetserver ca generate` command.
 
 If present, this file must be a YAML hash containing a `custom_attributes` key
@@ -965,7 +964,7 @@ EOT
       :mode => "0640",
       :owner => "service",
       :group => "service",
-      :desc => "Where puppet agent stores the password for its private key.
+      :desc => "Where OpenVox agent stores the password for its private key.
         Generally unused."
     },
     :hostcsr => {
@@ -1020,8 +1019,8 @@ EOT
     :ssl_trust_store => {
       :default => nil,
       :type => :file,
-      :desc => "A file containing CA certificates in PEM format that puppet should trust
-        when making HTTPS requests. This **only** applies to https requests to non-puppet
+      :desc => "A file containing CA certificates in PEM format that OpenVox should trust
+        when making HTTPS requests. This **only** applies to https requests to non-OpenVox
         infrastructure, such as retrieving file metadata and content from https file sources,
         puppet module tool and the 'http' report processor. This setting is ignored when
         making requests to puppet:// URLs such as catalog and report requests.",
@@ -1042,27 +1041,27 @@ EOT
           Whether certificate revocation checking should be enabled, and what level of
           checking should be performed.
 
-          When certificate revocation is enabled, Puppet expects the contents of its CRL
+          When certificate revocation is enabled, OpenVox expects the contents of its CRL
           to be one or more PEM-encoded CRLs concatenated together. When using a cert
           bundle, CRLs for all CAs in the chain of trust must be included in the crl file.
           The chain should be ordered from least to most authoritative, with the first CRL
           listed being for the root of the chain and the last being for the leaf CA.
 
-          When certificate_revocation is set to 'true' or 'chain', Puppet ensures
+          When certificate_revocation is set to 'true' or 'chain', OpenVox ensures
           that each CA in the chain of trust has not been revoked by its issuing CA.
 
-          When certificate_revocation is set to 'leaf', Puppet verifies certs against
+          When certificate_revocation is set to 'leaf', OpenVox verifies certs against
           the issuing CA's revocation list, but it does not verify the revocation status
           of the issuing CA or any CA above it within the chain of trust.
 
-          When certificate_revocation is set to 'false', Puppet disables all
+          When certificate_revocation is set to 'false', OpenVox disables all
           certificate revocation checking and does not attempt to download the CRL.
         EOT
     },
     :ciphers => {
       :default => 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256',
       :type => :string,
-      :desc => "The list of ciphersuites for TLS connections initiated by puppet. The
+      :desc => "The list of ciphersuites for TLS connections initiated by OpenVox. The
                 default value is chosen to support TLS 1.0 and up, but can be made
                 more restrictive if needed. The ciphersuites must be specified in OpenSSL
                 format, not IANA."
@@ -1120,7 +1119,7 @@ EOT
     settings.define_settings(
     :ca,
     :ca_name => {
-      :default => "Puppet CA: $certname",
+      :default => "OpenVox CA: $certname",
       :desc    => "The name to use the Certificate Authority certificate.",
     },
     :cadir => {
@@ -1167,18 +1166,18 @@ EOT
       :default => "$confdir/autosign.conf",
       :type => :autosign,
       :desc => "Whether (and how) to autosign certificate requests. This setting
-        is only relevant on a Puppet Server acting as a certificate authority (CA).
+        is only relevant on a OpenVox Server acting as a certificate authority (CA).
 
         Valid values are true (autosigns all certificate requests; not recommended),
         false (disables autosigning certificates), or the absolute path to a file.
 
         The file specified in this setting may be either a **configuration file**
-        or a **custom policy executable.** Puppet will automatically determine
-        what it is: If the Puppet user (see the `user` setting) can execute the
+        or a **custom policy executable.** OpenVox will automatically determine
+        what it is: If the OpenVox user (see the `user` setting) can execute the
         file, it will be treated as a policy executable; otherwise, it will be
         treated as a config file.
 
-        If a custom policy executable is configured, the CA Puppet Server will run it
+        If a custom policy executable is configured, the CA OpenVox Server will run it
         every time it receives a CSR. The executable will be passed the subject CN of the
         request _as a command line argument,_ and the contents of the CSR in PEM format
         _on stdin._ It should exit with a status of 0 if the cert should be autosigned
@@ -1189,7 +1188,7 @@ EOT
         the request.
 
         For info on autosign configuration files, see
-        [the guide to Puppet's config files](https://puppet.com/docs/puppet/latest/config_file_autosign.html).",
+        [the guide to OpenVox's config files](https://puppet.com/docs/puppet/latest/config_file_autosign.html).",
     },
     :allow_duplicate_certs => {
       :default    => false,
@@ -1207,7 +1206,7 @@ EOT
     :ca_refresh_interval => {
       :default    => "1d",
       :type       => :duration,
-      :desc       => "How often the Puppet agent refreshes its local CA
+      :desc       => "How often the OpenVox agent refreshes its local CA
          certificates. By default, CA certificates are refreshed every 24 hours. If a
          different interval is specified, the agent refreshes its CA certificates during
          the next agent run if the elapsed time since the certificates were last
@@ -1226,10 +1225,10 @@ EOT
     :crl_refresh_interval => {
       :default    => "1d",
       :type       => :duration,
-      :desc       => "How often the Puppet agent refreshes its local Certificate
+      :desc       => "How often the OpenVox agent refreshes its local Certificate
          Revocation List (CRL). By default, the CRL is refreshed every 24 hours. If
          a different interval is specified, the agent refreshes its CRL on the next
-         Puppet agent run if the elapsed time since the CRL was last refreshed
+         OpenVox agent run if the elapsed time since the CRL was last refreshed
          exceeds the specified interval.
 
          In general, the interval should be greater than the `runinterval` value.
@@ -1244,7 +1243,7 @@ EOT
     :hostcert_renewal_interval => {
       :default => "30d",
       :type    => :duration,
-      :desc => "How often the Puppet agent renews its client certificate. By
+      :desc => "How often the OpenVox agent renews its client certificate. By
          default, the client certificate is renewed 30 days before the certificate
          expires. If a different interval is specified, the agent renews its client
          certificate during the next agent run, assuming that the client certificate has
@@ -1277,19 +1276,19 @@ EOT
       :config_file_name => {
           :type     => :string,
           :default  => Puppet::Settings.default_config_file_name,
-          :desc     => "The name of the puppet config file.",
+          :desc     => "The name of the OpenVox config file.",
       },
       :config => {
           :type => :file,
           :default  => "$confdir/${config_file_name}",
-          :desc     => "The configuration file for the current puppet application.",
+          :desc     => "The configuration file for the current OpenVox application.",
       },
       :pidfile => {
           :type => :file,
           :default  => "$rundir/${run_mode}.pid",
           :desc     => "The file containing the PID of a running process.
             This file is intended to be used by service management frameworks
-            and monitoring systems to determine if a puppet process is still in
+            and monitoring systems to determine if a OpenVox process is still in
             the process table.",
       },
       :sourceaddress => {
@@ -1303,7 +1302,7 @@ EOT
       :default    => nil,
       :type       => :file_or_directory,
       :desc       => "The entry-point manifest for the primary server. This can be one file
-        or a directory of manifests to be evaluated in alphabetical order. Puppet manages
+        or a directory of manifests to be evaluated in alphabetical order. OpenVox manages
         this path as a directory if one exists or if the path ends with a / or \\.
 
         Setting a global value for `manifest` in puppet.conf is not allowed
@@ -1344,15 +1343,15 @@ EOT
   settings.define_settings(:server,
     :user => {
       :default    => "puppet",
-      :desc       => "The user Puppet Server will run as. Used to ensure
+      :desc       => "The user OpenVox Server will run as. Used to ensure
       the agent side processes (agent, apply, etc) create files and
-      directories readable by Puppet Server when necessary.",
+      directories readable by OpenVox Server when necessary.",
     },
     :group => {
       :default    => "puppet",
-      :desc       => "The group Puppet Server will run as. Used to ensure
+      :desc       => "The group OpenVox Server will run as. Used to ensure
       the agent side processes (agent, apply, etc) create files and
-      directories readable by Puppet Server when necessary.",
+      directories readable by OpenVox Server when necessary.",
     },
     :default_manifest => {
       :default    => "./manifests",
@@ -1363,7 +1362,7 @@ EOT
 
         This setting's value can be an absolute or relative path. An absolute path
         will make all environments default to the same main manifest; a relative
-        path will allow each environment to use its own manifest, and Puppet will
+        path will allow each environment to use its own manifest, and OpenVox will
         resolve the path relative to each environment's main directory.
 
         In either case, the path can point to a single file or to a directory of
@@ -1373,7 +1372,7 @@ EOT
       :default    => false,
       :type       => :boolean,
       :desc       => "Whether to disallow an environment-specific main manifest. When set
-        to `true`, Puppet will use the manifest specified in the `default_manifest` setting
+        to `true`, OpenVox will use the manifest specified in the `default_manifest` setting
         for all environments. If an environment specifies a different main manifest in its
         `environment.conf` file, catalog requests for that environment will fail with an error.
 
@@ -1388,14 +1387,14 @@ EOT
     :code => {
       :default    => "",
       :desc       => "Code to parse directly.  This is essentially only used
-      by `puppet`, and should only be set if you're writing your own Puppet
+      by `puppet`, and should only be set if you're writing your own OpenVox
       executable.",
     },
     :masterport => {
       :default    => 8140,
       :type       => :port,
-      :desc       => "The default port puppet subcommands use to communicate
-      with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
+      :desc       => "The default port OpenVox subcommands use to communicate
+      with OpenVox Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
     },
     :serverport => {
@@ -1439,7 +1438,7 @@ EOT
       :default    => "HTTP_X_CLIENT_DN",
       :desc       => "The header containing an authenticated client's SSL DN.
       This header must be set by the proxy to the authenticated client's SSL
-      DN (e.g., `/CN=puppet.puppetlabs.com`).  Puppet will parse out the Common
+      DN (e.g., `/CN=puppet.puppetlabs.com`).  OpenVox will parse out the Common
       Name (CN) from the Distinguished Name (DN) and use the value of the CN
       field for authorization.
 
@@ -1482,7 +1481,7 @@ EOT
         their names should be comma-separated, with whitespace allowed. (For example,
         `reports = http, store`.)
 
-        This setting is relevant to puppet server and puppet apply. The primary Puppet
+        This setting is relevant to OpenVox server and puppet apply. The primary OpenVox
         server will call these report handlers with the reports it receives from
         agent nodes, and puppet apply will call them with its own report. (In
         all cases, the node applying the catalog must have `report = true`.)
@@ -1545,14 +1544,14 @@ EOT
       :desc => "The explicit value used for the node name for all requests the agent
         makes to the primary server. WARNING: This setting is mutually exclusive with
         node_name_fact.  Changing this setting also requires changes to
-        Puppet Server's default [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html)."
+        OpenVox Server's default [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html)."
     },
     :node_name_fact => {
       :default => "",
       :desc => "The fact name used to determine the node name used for all requests the agent
         makes to the primary server. WARNING: This setting is mutually exclusive with
         node_name_value.  Changing this setting also requires changes to
-        Puppet Server's default [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html).",
+        OpenVox Server's default [auth.conf](https://puppet.com/docs/puppetserver/latest/config_file_auth.html).",
       :hook => proc do |value|
         if !value.empty? and Puppet[:node_name_value] != Puppet[:certname]
           raise "Cannot specify both the node_name_value and node_name_fact settings"
@@ -1563,15 +1562,15 @@ EOT
       :default => "$statedir/state.yaml",
       :type => :file,
       :mode => "0640",
-      :desc => "Where Puppet agent and Puppet Server store state associated
-        with the running configuration.  In the case of Puppet Server,
+      :desc => "Where OpenVox agent and OpenVox Server store state associated
+        with the running configuration.  In the case of OpenVox Server,
         this file reflects the state discovered through interacting
         with clients."
     },
     :statettl => {
       :default => "32d",
       :type    => :ttl,
-      :desc    => "How long the Puppet agent should cache when a resource was last checked or synced.
+      :desc    => "How long the OpenVox agent should cache when a resource was last checked or synced.
       #{AS_DURATION}
       A value of `0` or `unlimited` will disable cache pruning.
 
@@ -1612,7 +1611,7 @@ EOT
       :type => :file,
       :owner => "root",
       :mode => "0640",
-      :desc => "The file in which puppet agent stores a list of the classes
+      :desc => "The file in which the OpenVox agent stores a list of the classes
         associated with the retrieved configuration.  Can be loaded in
         the separate `puppet` executable using the `--loadclasses`
         option."},
@@ -1621,7 +1620,7 @@ EOT
       :type => :file,
       :owner => "root",
       :mode => "0640",
-      :desc => "The file in which puppet agent stores a list of the resources
+      :desc => "The file in which the OpenVox agent stores a list of the resources
         associated with the retrieved configuration." },
     :puppetdlog => {
       :default => "$logdir/puppetd.log",
@@ -1629,15 +1628,15 @@ EOT
       :owner => "root",
       :mode => "0640",
       :desc => "The fallback log file. This is only used when the `--logdest` option
-        is not specified AND Puppet is running on an operating system where both
+        is not specified AND OpenVox is running on an operating system where both
         the POSIX syslog service and the Windows Event Log are unavailable. (Currently,
         no supported operating systems match that description.)
 
-        Despite the name, both puppet agent and puppet server will use this file
+        Despite the name, both the OpenVox agent and server will use this file
         as the fallback logging destination.
 
         For control over logging destinations, see the `--logdest` command line
-        option in the manual pages for puppet server, puppet agent, and puppet
+        option in the manual pages for OpenVox server, agent, and
         apply. You can see man pages by running `puppet <SUBCOMMAND> --help`,
         or read them online at https://puppet.com/docs/puppet/latest/man/."
     },
@@ -1651,13 +1650,13 @@ EOT
     },
     :server => {
       :default => "puppet",
-      :desc => "The primary Puppet server to which the Puppet agent should connect.",
+      :desc => "The primary OpenVox server to which the OpenVox agent should connect.",
     },
     :server_list => {
       :default => [],
       :type => :server_list,
-      :desc => "The list of primary Puppet servers to which the Puppet agent should connect,
-        in the order that they will be tried. Each value should be a fully qualified domain name, followed by an optional ':' and port number. If a port is omitted, Puppet uses masterport for that host.",
+      :desc => "The list of primary OpenVox servers to which the OpenVox agent should connect,
+        in the order that they will be tried. Each value should be a fully qualified domain name, followed by an optional ':' and port number. If a port is omitted, OpenVox uses masterport for that host.",
     },
     :use_srv_records => {
       :default    => false,
@@ -1677,8 +1676,8 @@ EOT
     :ignoreschedules => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Boolean; whether puppet agent should ignore schedules.  This is useful
-      for initial puppet agent runs.",
+      :desc       => "Boolean; whether the OpenVox agent should ignore schedules.  This is useful
+      for initial OpenVox agent runs.",
     },
     :default_schedules => {
       :default    => true,
@@ -1689,18 +1688,17 @@ EOT
     :noop => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Whether to apply catalogs in noop mode, which allows Puppet to
-        partially simulate a normal run. This setting affects puppet agent and
-        puppet apply.
+      :desc       => "Whether to apply catalogs in noop mode, which allows OpenVox to
+        partially simulate a normal run. This setting affects the OpenVox agent and apply.
 
-        When running in noop mode, Puppet will check whether each resource is in sync,
+        When running in noop mode, OpenVox will check whether each resource is in sync,
         like it does when running normally. However, if a resource attribute is not in
-        the desired state (as declared in the catalog), Puppet will take no
+        the desired state (as declared in the catalog), OpenVox will take no
         action, and will instead report the changes it _would_ have made. These
-        simulated changes will appear in the report sent to the primary Puppet server, or
+        simulated changes will appear in the report sent to the primary OpenVox server, or
         be shown on the console if running puppet agent or puppet apply in the
         foreground. The simulated changes will not send refresh events to any
-        subscribing or notified resources, although Puppet will log that a refresh
+        subscribing or notified resources, although OpenVox will log that a refresh
         event _would_ have been sent.
 
         **Important note:**
@@ -1714,7 +1712,7 @@ EOT
     :runinterval => {
       :default  => "30m",
       :type     => :duration,
-      :desc     => "How often puppet agent applies the catalog.
+      :desc     => "How often the OpenVox agent applies the catalog.
           Note that a runinterval of 0 means \"run continuously\" rather than
           \"never run.\" #{AS_DURATION}",
     },
@@ -1722,7 +1720,7 @@ EOT
       :default  => "1h",
       :type     => :duration,
       :desc     => "The maximum amount of time an agent run is allowed to take.
-          A Puppet agent run that exceeds this timeout will be aborted. A value
+          A OpenVox agent run that exceeds this timeout will be aborted. A value
           of 0 disables the timeout. Defaults to 1 hour. #{AS_DURATION}",
     },
     :ca_server => {
@@ -1753,8 +1751,8 @@ EOT
       :default    => false,
       :type       => :boolean,
       :desc => "Whether to allow PSON serialization. When unable to serialize to
-        JSON or other formats, Puppet falls back to PSON. This option affects the
-        configuration management service responses of Puppet Server and the process by
+        JSON or other formats, OpenVox falls back to PSON. This option affects the
+        configuration management service responses of OpenVox Server and the process by
         which the agent saves its cached catalog. With a default value of `false`, this
         option is useful in preventing the loss of data because rich data cannot be
         serialized via PSON.",
@@ -1762,13 +1760,13 @@ EOT
     :agent_catalog_run_lockfile => {
       :default    => "$statedir/agent_catalog_run.lock",
       :type       => :string, # (#2888) Ensure this file is not added to the settings catalog.
-      :desc       => "A lock file to indicate that a puppet agent catalog run is currently in progress.
+      :desc       => "A lock file to indicate that an OpenVox agent catalog run is currently in progress.
         The file contains the pid of the process that holds the lock on the catalog run.",
     },
     :agent_disabled_lockfile => {
         :default    => "$statedir/agent_disabled.lock",
         :type       => :string,
-        :desc       => "A lock file to indicate that puppet agent runs have been administratively
+        :desc       => "A lock file to indicate that OpenVox agent runs have been administratively
           disabled.  File contains a JSON object with state information.",
     },
     :usecacheonfailure => {
@@ -1818,10 +1816,10 @@ EOT
       :default    => false,
       :type       => :boolean,
       :desc       => "Whether to only use the cached catalog rather than compiling a new catalog
-        on every run.  Puppet can be run with this enabled by default and then selectively
-        disabled when a recompile is desired. Because a Puppet agent using cached catalogs
+        on every run.  OpenVox can be run with this enabled by default and then selectively
+        disabled when a recompile is desired. Because an OpenVox agent using cached catalogs
         does not contact the primary server for a new catalog, it also does not upload facts at
-        the beginning of the Puppet run.",
+        the beginning of the run.",
     },
     :ignoremissingtypes => {
       :default    => false,
@@ -1858,7 +1856,7 @@ EOT
         If you restart an agent's puppet service with `splay` enabled, it
         recalculates its splay period and delays its first agent run after
         restarting for this new period. If you simultaneously restart a group of
-        puppet agents with `splay` enabled, their checkins to your primary servers
+        OpenVox agents with `splay` enabled, their checkins to your primary servers
         can be distributed more evenly.",
     },
     :clientbucketdir => {
@@ -1887,7 +1885,7 @@ EOT
       :desc     => "Whether the 'http' report processor should include the system
         certificate store when submitting reports to HTTPS URLs. If false, then
         the 'http' processor will only trust HTTPS report servers whose certificates
-        are issued by the puppet CA or one of its intermediate CAs. If true, the
+        are issued by the OpenVox CA or one of its intermediate CAs. If true, the
         processor will additionally trust CA certificates in the system's
         certificate store."
     },
@@ -1895,11 +1893,11 @@ EOT
       :default  => false,
       :type     => :boolean,
       :desc     => "Whether to send updated facts after every transaction. By default
-        puppet only submits facts at the beginning of the transaction before applying a
-        catalog. Since puppet can modify the state of the system, the value of the facts
-        may change after puppet finishes. Therefore, any facts stored in puppetdb may not
+        OpenVox only submits facts at the beginning of the transaction before applying a
+        catalog. Since OpenVox can modify the state of the system, the value of the facts
+        may change after OpenVox finishes. Therefore, any facts stored in puppetdb may not
         be consistent until the agent next runs, typically in 30 minutes. If this feature
-        is enabled, puppet will resubmit facts after applying its catalog, ensuring facts
+        is enabled, OpenVox will resubmit facts after applying its catalog, ensuring facts
         for the node stored in puppetdb are current. However, this will double the fact
         submission load on puppetdb, so it is disabled by default.",
     },
@@ -1907,19 +1905,19 @@ EOT
       :default  => nil,
       :type     => :directory,
       :mode     => "0755",
-      :desc     => "Where Puppet stores public files."
+      :desc     => "Where OpenVox stores public files."
     },
     :lastrunfile =>  {
       :default  => "$publicdir/last_run_summary.yaml",
       :type     => :file,
       :mode     => "0640",
-      :desc     => "Where puppet agent stores the last run report summary in yaml format."
+      :desc     => "Where OpenVox agent stores the last run report summary in yaml format."
     },
     :lastrunreport =>  {
       :default  => "$statedir/last_run_report.yaml",
       :type     => :file,
       :mode     => "0640",
-      :desc     => "Where Puppet Agent stores the last run report, by default, in yaml format.
+      :desc     => "Where OpenVox Agent stores the last run report, by default, in yaml format.
         The format of the report can be changed by setting the `cache` key of the `report` terminus
         in the [routes.yaml](https://puppet.com/docs/puppet/latest/config_file_routes.html) file.
         To avoid mismatches between content and file extension, this setting needs to be
@@ -1929,7 +1927,7 @@ EOT
       :default  => false,
       :type     => :boolean,
       :desc     => "Whether to create .dot graph files, which let you visualize the
-        dependency and containment relationships in Puppet's catalog. You
+        dependency and containment relationships in OpenVox's catalog. You
         can load and view these files with tools like
         [OmniGraffle](http://www.omnigroup.com/applications/omnigraffle/) (OS X)
         or [graphviz](http://www.graphviz.org/) (multi-platform).
@@ -1937,8 +1935,8 @@ EOT
         Graph files are created when _applying_ a catalog, so this setting
         should be used on nodes running `puppet agent` or `puppet apply`.
 
-        The `graphdir` setting determines where Puppet will save graphs. Note
-        that we don't save graphs for historical runs; Puppet will replace the
+        The `graphdir` setting determines where OpenVox will save graphs. Note
+        that we don't save graphs for historical runs; OpenVox will replace the
         previous .dot files with new ones every time it applies a catalog.
 
         See your graphing software's documentation for details on opening .dot
@@ -1953,36 +1951,36 @@ EOT
     :waitforcert => {
       :default  => "2m",
       :type     => :duration,
-      :desc     => "How frequently puppet agent should ask for a signed certificate.
+      :desc     => "How frequently OpenVox agent should ask for a signed certificate.
 
-      When starting for the first time, puppet agent will submit a certificate
+      When starting for the first time, the OpenVox agent will submit a certificate
       signing request (CSR) to the server named in the `ca_server` setting
-      (usually the primary Puppet server); this may be autosigned, or may need to be
+      (usually the primary OpenVox server); this may be autosigned, or may need to be
       approved by a human, depending on the CA server's configuration.
 
-      Puppet agent cannot apply configurations until its approved certificate is
+      The OpenVox agent cannot apply configurations until its approved certificate is
       available. Since the certificate may or may not be available immediately,
-      puppet agent will repeatedly try to fetch it at this interval. You can
+      the OpenVox agent will repeatedly try to fetch it at this interval. You can
       turn off waiting for certificates by specifying a time of 0, or a maximum
       amount of time to wait in the `maxwaitforcert` setting, in which case
-      puppet agent will exit if it cannot get a cert.
+      the OpenVox agent will exit if it cannot get a cert.
       #{AS_DURATION}",
     },
     :maxwaitforcert => {
       :default  => "unlimited",
       :type     => :ttl,
-      :desc     => "The maximum amount of time the Puppet agent should wait for its
-      certificate request to be signed. A value of `unlimited` will cause puppet agent
+      :desc     => "The maximum amount of time the OpenVox agent should wait for its
+      certificate request to be signed. A value of `unlimited` will cause the OpenVox agent
       to ask for a signed certificate indefinitely.
       #{AS_DURATION}",
     },
     :waitforlock => {
       :default  => "0",
       :type     => :duration,
-      :desc     => "How frequently puppet agent should try running when there is an
-      already ongoing puppet agent instance.
+      :desc     => "How frequently the OpenVox agent should try running when there is an
+      already ongoing agent instance.
 
-      This argument is by default disabled (value set to 0). In this case puppet agent will
+      This argument is by default disabled (value set to 0). In this case the OpenVox agent will
       immediately exit if it cannot run at that moment. When a value other than 0 is set, this
       can also be used in combination with the `maxwaitforlock` argument.
       #{AS_DURATION}",
@@ -1990,9 +1988,9 @@ EOT
     :maxwaitforlock => {
       :default  => "1m",
       :type     => :ttl,
-      :desc     => "The maximum amount of time the puppet agent should wait for an
-      already running puppet agent to finish before starting a new one. This is set by default to 1 minute.
-      A value of `unlimited` will cause puppet agent to wait indefinitely.
+      :desc     => "The maximum amount of time the OpenVox agent should wait for an
+      already running agent to finish before starting a new one. This is set by default to 1 minute.
+      A value of `unlimited` will cause the agent to wait indefinitely.
       #{AS_DURATION}",
     }
   )
@@ -2004,7 +2002,7 @@ EOT
     :plugindest => {
       :type       => :directory,
       :default    => "$libdir",
-      :desc       => "Where Puppet should store plugins that it pulls down from the central
+      :desc       => "Where OpenVox should store plugins that it pulls down from the central
       server.",
     },
     :pluginsource => {
@@ -2016,7 +2014,7 @@ EOT
     :pluginfactdest => {
       :type     => :directory,
       :default  => "$vardir/facts.d",
-      :desc     => "Where Puppet should store external facts that are being handled by pluginsync",
+      :desc     => "Where OpenVox should store external facts that are being handled by pluginsync",
     },
     :pluginfactsource => {
       :default  => "puppet:///pluginfacts",
@@ -2025,7 +2023,7 @@ EOT
     :localedest => {
       :type       => :directory,
       :default    => "$vardir/locales",
-      :desc       => "Where Puppet should store translation files that it pulls down from the central
+      :desc       => "Where OpenVox should store translation files that it pulls down from the central
       server.",
     },
     :localesource => {
@@ -2051,7 +2049,7 @@ EOT
     :ignore_plugin_errors => {
       :default    => false,
       :type       => :boolean,
-      :desc       => "Whether the puppet run should ignore errors during pluginsync. If the setting
+      :desc       => "Whether the OpenVox agent run should ignore errors during pluginsync. If the setting
         is false and there are errors during pluginsync, then the agent will abort the run and
         submit a report containing information about the failed run."
     }
@@ -2064,7 +2062,7 @@ EOT
     :factpath => {
       :type     => :path,
       :default  => "$vardir/lib/facter#{File::PATH_SEPARATOR}$vardir/facts",
-      :desc     => "Where Puppet should look for facts.  Multiple directories should
+      :desc     => "Where OpenVox should look for facts.  Multiple directories should
         be separated by the system path separator character. (The POSIX path
         separator is ':', and the Windows path separator is ';'.)",
 
@@ -2101,11 +2099,11 @@ EOT
     :preprocess_deferred => {
       :default => false,
       :type => :boolean,
-      :desc => "Whether Puppet should call deferred functions before applying
+      :desc => "Whether OpenVox should call deferred functions before applying
         the catalog. If set to `true`, all prerequisites required for the
-        deferred function must be satisfied before the Puppet run. If set to
+        deferred function must be satisfied before the OpenVox run. If set to
         `false`, deferred functions follow Puppet relationships and
-        ordering. In this way, Puppet can install the prerequisites required for a
+        ordering. In this way, OpenVox can install the prerequisites required for a
         deferred function and call the deferred function in the same run.",
     },
     :summarize => {
@@ -2120,7 +2118,7 @@ EOT
     :external_nodes => {
         :default  => "none",
         :desc     => "The external node classifier (ENC) script to use for node data.
-          Puppet combines this data with the main manifest to produce node catalogs.
+          OpenVox combines this data with the main manifest to produce node catalogs.
 
           To enable this setting, set the `node_terminus` setting to `exec`.
 
@@ -2285,7 +2283,7 @@ EOT
     :default => false,
     :type => :boolean,
     :desc => <<-'EOT'
-      Turns on experimental support for tasks and plans in the puppet language. This is for internal API use only.
+      Turns on experimental support for tasks and plans in the Puppet language. This is for internal API use only.
       Do not change this setting.
     EOT
     }

--- a/lib/puppet/face/help/global.erb
+++ b/lib/puppet/face/help/global.erb
@@ -13,4 +13,4 @@ Available subcommands:
 
 See 'puppet help <subcommand> <action>' for help on a specific subcommand action.
 See 'puppet help <subcommand>' for help on a specific subcommand.
-Puppet v<%= Puppet.version %>
+OpenVox v<%= Puppet.version %>

--- a/lib/puppet/face/node.rb
+++ b/lib/puppet/face/node.rb
@@ -7,7 +7,7 @@ Puppet::Indirector::Face.define(:node, '0.0.1') do
 
   summary _("View and manage node definitions.")
   description <<-'EOT'
-    This subcommand interacts with node objects, which are used by Puppet to
+    This subcommand interacts with node objects, which are used by OpenVox to
     build a catalog. A node object consists of the node's facts, environment,
     node parameters (exposed in the parser as top-scope variables), and classes.
   EOT

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -7,22 +7,22 @@ Puppet::Face.define(:plugin, '0.0.1') do
   copyright "Puppet Inc.", 2011
   license   _("Apache 2 license; see COPYING")
 
-  summary _("Interact with the Puppet plugin system.")
+  summary _("Interact with the OpenVox plugin system.")
   description <<-'EOT'
-    This subcommand provides network access to the puppet master's store of
+    This subcommand provides network access to the OpenVox server's store of
     plugins.
 
-    The puppet master serves Ruby code collected from the `lib` directories
+    The OpenVox server serves Ruby code collected from the `lib` directories
     of its modules. These plugins can be used on agent nodes to extend
     Facter and implement custom types and providers. Plugins are normally
-    downloaded by puppet agent during the course of a run.
+    downloaded by the OpenVox agent during the course of a run.
   EOT
 
   action :download do
     summary _("Download plugins from the puppet master.")
     description <<-'EOT'
-      Downloads plugins from the configured puppet master. Any plugins
-      downloaded in this way will be used in all subsequent Puppet activity.
+      Downloads plugins from the configured OpenVox server. Any plugins
+      downloaded in this way will be used in all subsequent OpenVox activity.
       This action modifies files on disk.
     EOT
     returns _(<<-'EOT')

--- a/lib/puppet/face/report.rb
+++ b/lib/puppet/face/report.rb
@@ -27,7 +27,7 @@ Puppet::Indirector::Face.define(:report, '0.0.1') do
   action(:submit) do
     summary _("API only: submit a report with error handling.")
     description <<-'EOT'
-      API only: Submits a report to the puppet master. This action is
+      API only: Submits a report to the OpenVox server. This action is
       essentially a shortcut and wrapper for the `save` action with the `rest`
       terminus, and provides additional details in the event of a failure.
     EOT

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -11,7 +11,7 @@ require 'yaml'
 require 'uri'
 
 class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
-  desc "Compiles catalogs on demand using Puppet's compiler."
+  desc "Compiles catalogs on demand."
 
   include Puppet::Util
   include Puppet::Util::Checksums

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -5,7 +5,7 @@ require_relative '../../../puppet/indirector/code'
 
 class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
   desc "Retrieve facts from Facter.  This provides a somewhat abstract interface
-    between Puppet and Facter.  It's only `somewhat` abstract because it always
+    between OpenVox and Facter.  It's only `somewhat` abstract because it always
     returns the local host's facts, regardless of what you attempt to find."
 
   def allow_remote_requests?

--- a/lib/puppet/indirector/node/rest.rb
+++ b/lib/puppet/indirector/node/rest.rb
@@ -4,7 +4,7 @@ require_relative '../../../puppet/node'
 require_relative '../../../puppet/indirector/rest'
 
 class Puppet::Node::Rest < Puppet::Indirector::REST
-  desc "Get a node via REST. Puppet agent uses this to allow the puppet master
+  desc "Get a node via REST. OpenVox agent uses this to allow the OpenVox server
     to override its environment."
 
   def find(request)

--- a/lib/puppet/indirector/report/processor.rb
+++ b/lib/puppet/indirector/report/processor.rb
@@ -5,7 +5,7 @@ require_relative '../../../puppet/indirector/code'
 require_relative '../../../puppet/reports'
 
 class Puppet::Transaction::Report::Processor < Puppet::Indirector::Code
-  desc "Puppet's report processor.  Processes the report with each of
+  desc "Processes the report with each of
     the report types listed in the 'reports' setting."
 
   def initialize

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -148,7 +148,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
           @label_to_path_map[job["Label"]] = filepath
         else
           # TRANSLATORS 'plist' and label' should not be translated
-          Puppet.debug(_("The %{file} plist does not contain a 'label' key; Puppet is skipping it") % { file: filepath })
+          Puppet.debug(_("The %{file} plist does not contain a 'label' key; skipping it") % { file: filepath })
           next
         end
       end

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -224,7 +224,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     when 'iterations'
       Integer(embedded_binary_plist['SALTED-SHA512-PBKDF2'][field])
     else
-      raise Puppet::Error, "Puppet has tried to read an incorrect value from the user #{user_name} in the SALTED-SHA512-PBKDF2 hash. Acceptable fields are 'salt', 'entropy', or 'iterations'."
+      raise Puppet::Error, "Incorrect value read from the user #{user_name} in the SALTED-SHA512-PBKDF2 hash. Acceptable fields are 'salt', 'entropy', or 'iterations'."
     end
   end
 
@@ -414,7 +414,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   def salt=(value)
     if Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.15') >= 0
       if value.length != 64
-        self.fail "macOS versions 10.15 and higher require the salt to be 32-bytes. Since Puppet's user resource requires the value to be hex encoded, the length of the salt's string must be 64. Please check your salt and try again."
+        self.fail "macOS versions 10.15 and higher require the salt to be 32-bytes. Since the user resource requires the value to be hex encoded, the length of the salt's string must be 64. Please check your salt and try again."
       end
     end
     if Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.7') > 0
@@ -452,7 +452,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     define_method("#{setter_method}=") do |value|
       if @property_hash[setter_method.intern]
         if %w[home uid].include?(setter_method)
-          raise Puppet::Error, "OS X version #{self.class.get_os_version} does not allow changing #{setter_method} using puppet"
+          raise Puppet::Error, "OS X version #{self.class.get_os_version} does not allow changing #{setter_method}"
         end
 
         begin
@@ -667,7 +667,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     when 'iterations'
       shadow_hash_data['SALTED-SHA512-PBKDF2'][field] = Integer(value)
     else
-      raise Puppet::Error "Puppet has tried to set an incorrect field for the 'SALTED-SHA512-PBKDF2' hash. Acceptable fields are 'salt', 'entropy', or 'iterations'."
+      raise Puppet::Error "Incorrect field for the 'SALTED-SHA512-PBKDF2' hash. Acceptable fields are 'salt', 'entropy', or 'iterations'."
     end
 
     # on 10.8, this field *must* contain 8 stars, or authentication will

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -38,7 +38,7 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     when 'logdir'
       val = 'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
     when 'hiera_config'
-      val = '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
+      val = '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, OpenVox uses that instead.'
     when 'certname'
       val = "the Host's fully qualified domain name, as determined by Facter"
     when 'hostname'
@@ -67,7 +67,7 @@ config.header = <<~EOT
 
   * Each of these settings can be specified in `puppet.conf` or on the
     command line.
-  * Puppet Enterprise (PE) and open source Puppet share the configuration settings
+  * OpenVox, Puppet Enterprise (PE) and open source Puppet share the configuration settings
     documented here. However, PE defaults differ from open source defaults for some
     settings, such as `node_terminus`, `storeconfigs`, `always_retry_plugins`,
     `disable18n`, `environment_timeout` (when Code Manager is enabled), and the
@@ -78,7 +78,7 @@ config.header = <<~EOT
     `--no-setting` instead of `--setting (true|false)`. (Using `--setting false`
     results in "Error: Could not parse application options: needless argument".)
   * Settings can be interpolated as `$variables` in other settings; `$environment`
-    is special, in that puppet master will interpolate each agent node's
+    is special, in that OpenVox server will interpolate each agent node's
     environment instead of its own.
   * Multiple values should be specified as comma-separated lists; multiple
     directories should be separated with the system path separator (usually
@@ -90,11 +90,11 @@ config.header = <<~EOT
     '3600' which is equivalent to '1h' (one hour), and '1825d' which is equivalent
     to '5y' (5 years).
   * If you use the `splay` setting, note that the period that it waits changes
-    each time the Puppet agent is restarted.
+    each time the OpenVox agent is restarted.
   * Settings that take a single file or directory can optionally set the owner,
     group, and mode for their value: `rundir = $vardir/run { owner = puppet,
     group = puppet, mode = 644 }`
-  * The Puppet executables ignores any setting that isn't relevant to
+  * The OpenVox executables ignores any setting that isn't relevant to
     their function.
 
   See the [configuration guide][confguide] for more details.

--- a/lib/puppet/reference/function.rb
+++ b/lib/puppet/reference/function.rb
@@ -4,16 +4,16 @@ function = Puppet::Util::Reference.newreference :function, :doc => "All function
   Puppet::Parser::Functions.functiondocs
 end
 function.header = "
-There are two types of functions in Puppet: Statements and rvalues.
+There are two types of functions in the Puppet language: Statements and rvalues.
 Statements stand on their own and do not return arguments; they are used for
 performing stand-alone work like importing.  Rvalues return values and can
 only be used in a statement requiring a value, such as an assignment or a case
 statement.
 
-Functions execute on the Puppet master.  They do not execute on the Puppet agent.
-Hence they only have access to the commands and data available on the Puppet master
+Functions execute on the OpenVox server.  They do not execute on the OpenVox agent.
+Hence they only have access to the commands and data available on the OpenVox server
 host.
 
-Here are the functions available in Puppet:
+Here are the functions available in the Puppet language:
 
 "

--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -36,7 +36,7 @@ reference.header = <<~HEADER
 
   ## About Indirection
 
-  Puppet's indirector support pluggable backends (termini) for a variety of key-value stores (indirections).
+  OpenVox's indirector support pluggable backends (termini) for a variety of key-value stores (indirections).
   Each indirection type corresponds to a particular Ruby class (the "Indirected Class" below) and values are instances of that class.
   Each instance's key is available from its `name` method.
   The termini can be local (e.g., on-disk files) or remote (e.g., using a REST interface to talk to a puppet master).

--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-Puppet::Util::Reference.newreference :metaparameter, :doc => "All Puppet metaparameters and all their details" do
+Puppet::Util::Reference.newreference :metaparameter, :doc => "All Puppet language metaparameters and all their details" do
   str = %{
 
 Metaparameters are attributes that work with any resource type, including custom
 types and defined types.
 
-In general, they affect _Puppet's_ behavior rather than the desired state of the
+In general, they affect _OpenVox's_ behavior rather than the desired state of the
 resource. Metaparameters do things like add metadata to a resource (`alias`,
 `tag`), set limits on when the resource should be synced (`require`, `schedule`,
-etc.), prevent Puppet from making changes (`noop`), and change logging verbosity
+etc.), prevent OpenVox from making changes (`noop`), and change logging verbosity
 (`loglevel`).
 
 ## Available Metaparameters

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -107,7 +107,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   ret
 end
 providers.header = "
-Puppet resource types are usually backed by multiple implementations called `providers`,
+OpenVox resource types are usually backed by multiple implementations called `providers`,
 which handle variance between platforms and tools.
 
 Different providers are suitable or unsuitable on different platforms based on things

--- a/lib/puppet/reference/report.rb
+++ b/lib/puppet/reference/report.rb
@@ -7,12 +7,12 @@ report = Puppet::Util::Reference.newreference :report, :doc => "All available tr
 end
 
 report.header = "
-Puppet can generate a report after applying a catalog. This report includes
+OpenVox can generate a report after applying a catalog. This report includes
 events, log messages, resource statuses, and metrics and metadata about the run.
-Puppet agent sends its report to a Puppet master server, and Puppet apply
+OpenVox agent sends its report to a OpenVox server, and OpenVox apply
 processes its own reports.
 
-Puppet master and Puppet apply will handle every report with a set of report
+The OpenVox server and OpenVox apply will handle every report with a set of report
 processors, configurable with the `reports` setting in puppet.conf. This page
 documents the built-in report processors.
 

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1089,12 +1089,12 @@ class Puppet::Settings
   def to_config
     str = %(The configuration file for #{Puppet.run_mode.name}.  Note that this file
 is likely to have unused settings in it; any setting that's
-valid anywhere in Puppet can be in any config file, even if it's not used.
+valid anywhere in OpenVox can be in any config file, even if it's not used.
 
 Every section can specify three special parameters: owner, group, and mode.
 These parameters affect the required permissions of any files specified after
-their specification.  Puppet will sometimes use these parameters to check its
-own configured state, so they can be used to make Puppet a bit more self-managing.
+their specification.  OpenVox will sometimes use these parameters to check its
+own configured state, so they can be used to make OpenVox a bit more self-managing.
 
 The file format supports octothorpe-commented lines, but not partial-line comments.
 
@@ -1142,7 +1142,7 @@ Generated on #{Time.now}.
       begin
         catalog = to_catalog(*sections).to_ral
       rescue => detail
-        Puppet.log_and_raise(detail, "Could not create resources for managing Puppet's files and directories in sections #{sections.inspect}: #{detail}")
+        Puppet.log_and_raise(detail, "Could not create resources for managing OpenVox's files and directories in sections #{sections.inspect}: #{detail}")
       end
 
       catalog.host_config = false

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -175,7 +175,7 @@ module Puppet
             puts colorize(:hred, _("Error: Could not parse application options: invalid option: %{opt}") % { opt: args[0] })
             exit 1
           else
-            puts _("See 'puppet help' for help on available puppet subcommands")
+            puts _("See 'puppet help' for help on available subcommands")
           end
         end
       end
@@ -188,7 +188,7 @@ module Puppet
         end
 
         def run
-          puts colorize(:hred, _("Error: Unknown Puppet subcommand '%{cmd}'") % { cmd: @subcommand_name })
+          puts colorize(:hred, _("Error: Unknown subcommand '%{cmd}'") % { cmd: @subcommand_name })
           super
           exit 1
         end

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -193,7 +193,7 @@ class Puppet::Util::FileType
     # Read a specific @path's cron tab.
     def read
       unless Puppet::Util.uid(@path)
-        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case Puppet creates them in the middle of the run.") % { path: @path }
+        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case OpenVox creates them in the middle of the run.") % { path: @path }
 
         return ""
       end
@@ -204,7 +204,7 @@ class Puppet::Util::FileType
       when /no crontab for/
         ""
       when /are not allowed to/
-        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case Puppet authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
+        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case OpenVox authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
 
         ""
       else
@@ -258,7 +258,7 @@ class Puppet::Util::FileType
     # Read a specific @path's cron tab.
     def read
       unless Puppet::Util.uid(@path)
-        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case Puppet creates them in the middle of the run.") % { path: @path }
+        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case OpenVox creates them in the middle of the run.") % { path: @path }
 
         return ""
       end
@@ -269,7 +269,7 @@ class Puppet::Util::FileType
       when /can't open your crontab/
         ""
       when /you are not authorized to use cron/
-        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case Puppet authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
+        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case OpenVox authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
 
         ""
       else
@@ -309,7 +309,7 @@ class Puppet::Util::FileType
     # Read a specific @path's cron tab.
     def read
       unless Puppet::Util.uid(@path)
-        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case Puppet creates them in the middle of the run.") % { path: @path }
+        Puppet.debug _("The %{path} user does not exist. Treating their crontab file as empty in case OpenVox creates them in the middle of the run.") % { path: @path }
 
         return ""
       end
@@ -320,7 +320,7 @@ class Puppet::Util::FileType
       when /open.*in.*directory/
         ""
       when /not.*authorized.*cron/
-        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case Puppet authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
+        Puppet.debug _("The %{path} user is not authorized to use cron. Their crontab file is treated as empty in case OpenVox authorizes them in the middle of the run (by, for example, modifying the cron.deny or cron.allow files).") % { path: @path }
 
         ""
       else

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -288,7 +288,7 @@ module Puppet::Util::Windows::ADSI
       rescue WIN32OLERuntimeError => e
         # ERROR_BAD_USERNAME 2202L from winerror.h
         if e.message =~ /8007089A/m
-          raise Puppet::Error, _("Puppet is not able to create/delete domain %{object_class} objects with the %{object_class} resource.") % { object_class: object_class }
+          raise Puppet::Error, _("Unable to create/delete domain %{object_class} objects with the %{object_class} resource.") % { object_class: object_class }
         end
 
         raise Puppet::Error.new(_("%{object_class} update failed: %{error}") % { object_class: object_class.capitalize, error: e }, e)

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,24 +1,24 @@
 Gem::Specification.new do |spec|
-  spec.name = "puppet"
+  spec.name = "openvox"
   spec.version = "8.11.0"
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
   spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
-  spec.authors = ["Puppet Labs"]
+  spec.authors = ["Vox Pupuli"]
   spec.date = "2012-08-17"
   spec.description = <<~EOF
-    Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+    OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
     (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
   EOF
-  spec.email = "info@puppetlabs.com"
+  spec.email = "pmc@voxpupuli.org."
   spec.executables = ["puppet"]
   spec.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
   spec.license = "Apache-2.0"
-  spec.homepage = "https://github.com/puppetlabs/puppet"
-  spec.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
+  spec.homepage = "https://github.com/OpenVoxProject/puppet"
+  spec.rdoc_options = ["--title", "OpenVox - Configuration Management", "--main", "README", "--line-numbers"]
   spec.require_paths = ["lib"]
-  spec.summary = "Puppet, an automated configuration management tool"
+  spec.summary = "OpenVox, a community implementation of Puppet -- an automated configuration management tool"
   spec.specification_version = 4
   spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
   spec.add_runtime_dependency('deep_merge', '~> 1.0')

--- a/rakelib/generate_references.rake
+++ b/rakelib/generate_references.rake
@@ -287,7 +287,7 @@ namespace :references do
     variables = {
       sha: sha,
       now: now,
-      title: 'Puppet Man Pages',
+      title: 'OpenVox Man Pages',
       core_apps: core_apps,
       occasional_apps: occasional_apps,
       weird_apps: weird_apps

--- a/rakelib/man/puppet.erb
+++ b/rakelib/man/puppet.erb
@@ -7,8 +7,9 @@ puppet(8) - an automated configuration management tool
 
 ## DESCRIPTION
 
-Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+OpenVox, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
 (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
+This is a community fork of Puppet and currently provides the `puppet` command for compatibility reasons.
 
 ## COMMANDS
 

--- a/rakelib/manpages.rake
+++ b/rakelib/manpages.rake
@@ -1,4 +1,4 @@
-desc "Build Puppet manpages"
+desc "Build OpenVox manpages"
 task :gen_manpages do
   require 'puppet/face'
   require 'fileutils'
@@ -12,7 +12,7 @@ task :gen_manpages do
   faces.delete('strings')
   apps = non_face_applications + faces
 
-  ronn_args = '--manual="Puppet manual" --organization="Puppet, Inc." --roff'
+  ronn_args = '--manual="OpenVox manual" --organization="Vox Pupuli" --roff'
 
   unless ENV['SOURCE_DATE_EPOCH'].nil?
     source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d')

--- a/rakelib/references/configuration.erb
+++ b/rakelib/references/configuration.erb
@@ -8,6 +8,6 @@ canonical: "/puppet/latest/configuration.html"
 
 # Configuration Reference
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 <%= body %>

--- a/rakelib/references/function.erb
+++ b/rakelib/references/function.erb
@@ -9,13 +9,13 @@ toc: columns
 
 # Built-in function reference
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 
 
-This page is a list of Puppet's built-in functions, with descriptions of what they do and how to use them.
+This page is a list of OpenVox's built-in functions, with descriptions of what they do and how to use them.
 
-Functions are plugins you can call during catalog compilation. A call to any function is an expression that resolves to a value. For more information on how to call functions, see [the language reference page about function calls.](lang_functions.dita) 
+Functions are plugins you can call during catalog compilation. A call to any function is an expression that resolves to a value. For more information on how to call functions, see [the language reference page about function calls.](lang_functions.dita)
 
 Many of these function descriptions include auto-detected _signatures,_ which are short reminders of the function's allowed arguments. These signatures aren't identical to the syntax you use to call the function; instead, they resemble a parameter list from a Puppet [class](lang_classes.dita), [defined resource type](lang_defined_types.dita), [function](lang_write_functions_in_puppet.dita), or [lambda](lang_lambdas.dita). The syntax of a signature is:
 

--- a/rakelib/references/man.erb
+++ b/rakelib/references/man.erb
@@ -7,6 +7,6 @@ canonical: "<%= canonical %>"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 <%= body %>

--- a/rakelib/references/man/overview.erb
+++ b/rakelib/references/man/overview.erb
@@ -7,16 +7,16 @@ canonical: "/puppet/latest/man/overview.html"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 
 
-Puppet's command line tools consist of a single `puppet` binary with many subcommands. The following subcommands are available in this version of Puppet:
+OpenVox's command line tools consist of a single `puppet` binary with many subcommands. The following subcommands are available in this version of OpenVox:
 
 Core Tools
 -----
 
-These subcommands form the core of Puppet's tool set, and every user should understand what they do.
+These subcommands form the core of OpenVox's tool set, and every user should understand what they do.
 
 <% core_apps.each do |app| -%>
 - [puppet <%= app %>](<%= app %>.md)
@@ -38,7 +38,7 @@ Many or most users need to use these subcommands at some point, but they aren't 
 Niche subcommands
 -----
 
-Most users can ignore these subcommands. They're only useful for certain niche workflows, and most of them are interfaces to Puppet's internal subsystems.
+Most users can ignore these subcommands. They're only useful for certain niche workflows, and most of them are interfaces to OpenVox's internal subsystems.
 
 <% weird_apps.each do |app| -%>
 - [puppet <%= app %>](<%= app %>.md)

--- a/rakelib/references/metaparameter.erb
+++ b/rakelib/references/metaparameter.erb
@@ -8,6 +8,6 @@ canonical: "/puppet/latest/metaparameter.html"
 
 # Metaparameter Reference
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 <%= body %>

--- a/rakelib/references/report.erb
+++ b/rakelib/references/report.erb
@@ -8,6 +8,6 @@ canonical: "/puppet/latest/report.html"
 
 # Report Reference
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 <%= body %>

--- a/rakelib/references/types/overview.erb
+++ b/rakelib/references/types/overview.erb
@@ -7,7 +7,7 @@ canonical: "/puppet/latest/types/overview.md"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 ## List of resource types
 
@@ -21,13 +21,13 @@ canonical: "/puppet/latest/types/overview.md"
 
 ### Built-in types and custom types
 
-This is the documentation for Puppet's built-in resource types and providers. Additional resource types are distributed in Puppet modules.
+This is the documentation for OpenVox's built-in resource types and providers. Additional resource types are distributed in Puppet modules.
 
 You can find and install modules by browsing the
 [Puppet Forge](http://forge.puppet.com). See each module's documentation for
 information on how to use its custom resource types. For more information about creating custom types, see [Custom resources](/docs/puppet/latest/custom_resources.html).
 
-> As of Puppet 6.0, some resource types were removed from Puppet and repackaged as individual modules. These supported type modules are still included in the `puppet-agent` package, so you don't have to download them from the Forge. See the complete list of affected types in the [supported type modules](#supported-type-modules-in-puppet-agent) section.
+> As of Puppet 6.0, some resource types were removed from Puppet and repackaged as individual modules. These supported type modules are still included in the `openvox-agent` package, so you don't have to download them from the Forge. See the complete list of affected types in the [supported type modules](#supported-type-modules-in-puppet-agent) section.
 
 ### Declaring resources
 
@@ -93,7 +93,7 @@ on `file` resources).
 _Providers_ implement the same resource type on different kinds of systems.
 They usually do this by calling out to external commands.
 
-Although Puppet automatically selects an appropriate default provider, you
+Although OpenVox automatically selects an appropriate default provider, you
 can override the default with the `provider` attribute. (For example, `package`
 resources on Red Hat systems default to the `yum` provider, but you can specify
 `provider => gem` to install Ruby libraries with the `gem` command.)
@@ -108,7 +108,7 @@ shell path.
 _Features_ are abilities that some providers might not support. Generally, a
 feature corresponds to some allowed values for a resource attribute.
 
-This is often the case with the `ensure` attribute. In most types, Puppet
+This is often the case with the `ensure` attribute. In most types, OpenVox
 doesn't create new resources when omitting `ensure` but still modifies existing
 resources to match specifications in the manifest. However, in some types this
 isn't always the case, or additional values provide more granular control. For
@@ -123,9 +123,9 @@ declare which features they provide.
 
 In Puppet 6.0, we removed some of Puppet's built-in types and moved them into individual modules.
 
-### Supported type modules in `puppet-agent`
+### Supported type modules in `openvox-agent`
 
-The following types are included in supported modules on the Forge. However, they are also included in the `puppet-agent` package, so you do not have to install them separately. See each module's README for detailed information about that type.
+The following types are included in supported modules on the Forge. However, they are also included in the `openvox-agent` package, so you do not have to install them separately. See each module's README for detailed information about that type.
 
 - [`augeas`](https://forge.puppet.com/puppetlabs/augeas_core)
 - [`cron`](https://forge.puppet.com/puppetlabs/cron_core)
@@ -143,7 +143,7 @@ The following types are included in supported modules on the Forge. However, the
 
 ### Type modules available on the Forge
 
-The following types are contained in modules that are maintained, but are not repackaged into Puppet agent. If you need to use them, you must install the modules separately. 
+The following types are contained in modules that are maintained, but are not repackaged into OpenVox agent. If you need to use them, you must install the modules separately.
 
 - [`k5login`](https://forge.puppet.com/puppetlabs/k5login_core)
 - [`mailalias`](https://forge.puppet.com/puppetlabs/mailalias_core)
@@ -161,6 +161,6 @@ The following types were deprecated with Puppet 6.0.0. They are available in mod
 - [`router`](https://github.com/puppetlabs/puppetlabs-network_device_core) (Use the updated [`cisco_ios module`](https://forge.puppet.com/puppetlabs/cisco_ios/readme) instead.
 - [`vlan`](https://github.com/puppetlabs/puppetlabs-network_device_core) (Use the updated [`cisco_ios module`](https://forge.puppet.com/puppetlabs/cisco_ios/readme) instead.
 
-## Puppet core types
+## Puppet language core types
 
-For a list of core Puppet types, see the [core types cheat sheet][core-types-cheatsheet].
+For a list of core Puppet language types, see the [core types cheat sheet][core-types-cheatsheet].

--- a/rakelib/references/types/single_type.erb
+++ b/rakelib/references/types/single_type.erb
@@ -7,7 +7,7 @@ canonical: "/puppet/latest/types/<%= type %>.html"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 
 

--- a/rakelib/references/unified_type.erb
+++ b/rakelib/references/unified_type.erb
@@ -9,7 +9,7 @@ toc: columns
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 
 
@@ -17,7 +17,7 @@ toc: columns
 
 ### Built-in types and custom types
 
-This is the documentation for Puppet's built-in resource types and providers. Additional resource types are distributed in Puppet modules.
+This is the documentation for OpenVox's built-in resource types and providers. Additional resource types are distributed in Puppet modules.
 
 You can find and install modules by browsing the
 [Puppet Forge](http://forge.puppet.com). See each module's documentation for
@@ -89,7 +89,7 @@ on `file` resources).
 _Providers_ implement the same resource type on different kinds of systems.
 They usually do this by calling out to external commands.
 
-Although Puppet automatically selects an appropriate default provider, you
+Although OpenVox automatically selects an appropriate default provider, you
 can override the default with the `provider` attribute. (For example, `package`
 resources on Red Hat systems default to the `yum` provider, but you can specify
 `provider => gem` to install Ruby libraries with the `gem` command.)
@@ -104,7 +104,7 @@ shell path.
 _Features_ are abilities that some providers might not support. Generally, a
 feature corresponds to some allowed values for a resource attribute.
 
-This is often the case with the `ensure` attribute. In most types, Puppet
+This is often the case with the `ensure` attribute. In most types, OpenVox
 doesn't create new resources when omitting `ensure` but still modifies existing
 resources to match specifications in the manifest. However, in some types this
 isn't always the case, or additional values provide more granular control. For
@@ -139,7 +139,7 @@ The following types are included in supported modules on the Forge. However, the
 
 ### Type modules available on the Forge
 
-The following types are contained in modules that are maintained, but are not repackaged into Puppet agent. If you need to use them, you must install the modules separately. 
+The following types are contained in modules that are maintained, but are not repackaged into Puppet agent. If you need to use them, you must install the modules separately.
 
 - [`k5login`](https://forge.puppet.com/puppetlabs/k5login_core)
 - [`mailalias`](https://forge.puppet.com/puppetlabs/mailalias_core)


### PR DESCRIPTION
This will debrand the common things like `puppet help` and the man
pages. I think I got all the command output that includes the name of
the tool.

It also does a quick pass over the docs generation system. We aren't
building these yet, but we will at some point.

If you'd like to help, then the easiest way to do so is to check out
this branch/PR and directly add your own commits.

Guidelines
- Do not change any command names.
- *Do not change anything functional!!*
- If any command output includes the name of the tool, change it as
  appropriate.
    - if the name is extraneous, then just remove it. For example in the
      message "cannot find puppet server" I just removed the word
      "puppet".
- When there is a reference to 'Puppet' that means 'the Puppet language'
  then change it to 'the Puppet language' to be more precise. (OpenVox
  implements the Puppet language. There's no such thing as an OpenVox
  language.)
- Do minor content editing for readability as appropriate.
- We are currently focusing only on user experience and branding. It
  should be very clear to a user that they're running the OpenVox
  implementation of Puppet. It's not yet important that all the internal
  and developer documentation or comments reflect this.
