### PR TITLE
removes a gem that hasn't been updated in 15 years

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group(:documentation, optional: true) do
   gem 'gettext-setup', '~> 1.0', require: false, platforms: [:ruby]
-  gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
+  gem 'ronn-ng', '~> 0.10.1', require: false, platforms: [:ruby]
   gem 'puppet-strings', require: false, platforms: [:ruby]
   gem 'pandoc-ruby', require: false, platforms: [:ruby]
 end


### PR DESCRIPTION
Of course it broke. The newly generated man pages are quite different,
but they appear to render the same. We'll want to go through them again
as we improve our branding & docs.
