### PR TITLE
First pass at debranding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group(:documentation, optional: true) do
   gem 'gettext-setup', '~> 1.0', require: false, platforms: [:ruby]
-  gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
+  gem 'ronn-ng', '~> 0.10.1', require: false, platforms: [:ruby]
   gem 'puppet-strings', require: false, platforms: [:ruby]
   gem 'pandoc-ruby', require: false, platforms: [:ruby]
 end

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# Puppet
+# OpenVox
 
-![RSpec tests](https://github.com/puppetlabs/puppet/workflows/RSpec%20tests/badge.svg)
-[![Gem Version](https://badge.fury.io/rb/puppet.svg)](https://badge.fury.io/rb/puppet)
-[![Inline docs](https://inch-ci.org/github/puppetlabs/puppet.svg)](https://inch-ci.org/github/puppetlabs/puppet)
-
-Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs
+OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs
 administrative tasks (such as adding users, installing packages, and updating server
 configurations) based on a centralized specification.
 
 ## Documentation
 
-Documentation for Puppet and related projects can be found online at the
-[Puppet Docs site](https://puppet.com/docs).
+As of now, OpenVox is effectively the same as the original Puppet™️ packages, aside from some minor build pipeline changes and package renaming.
+This means that aside from the installation, all Puppet™️ docs and tutorials will still be completely applicable.
+As the OpenVox project matures, we will create more documentation, guides, and tutorials.
+For the time being though, now you’ll want to hop over to [Puppet’s own documentation](https://puppet.com/docs) and go from there.
 
 ### HTTP API
 
@@ -19,36 +17,37 @@ Documentation for Puppet and related projects can be found online at the
 
 ## Installation
 
-The best way to run Puppet is with [Puppet Enterprise (PE)](https://puppet.com/products/puppet-enterprise/),
-which also includes orchestration features, a web console, and professional support.
-The PE documentation is [available here.](https://puppet.com/docs/pe/latest)
+To install OpenVox,
+[see our installation guide.](https://voxpupuli.org/openvox/install/) and [quickstart page](https://voxpupuli.org/openvox/quickstart/).
 
-To install an open source release of Puppet,
-[see the installation guide on the docs site.](https://puppet.com/docs/puppet/latest/installing_and_upgrading.html)
-
-If you need to run Puppet from source as a tester or developer,
+If you need to run OpenVox from source as a tester or developer,
 see the [Quick Start to Developing on Puppet](docs/quickstart.md) guide.
 
 ## Developing and Contributing
 
 We'd love to get contributions from you! For a quick guide to getting your
 system setup for developing, take a look at our [Quickstart
-Guide](https://github.com/puppetlabs/puppet/blob/main/docs/quickstart.md). Once you are up and running, take a look at the
-[Contribution Documents](https://github.com/puppetlabs/.github/blob/main/CONTRIBUTING.md) to see how to get your changes merged
+Guide](docs/quickstart.md). Once you are up and running, take a look at the
+[Contribution Documents](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) to see how to get your changes merged
 in.
 
 For more complete docs on developing with Puppet, take a look at the
-rest of the [developer documents](https://github.com/puppetlabs/puppet/blob/main/docs/index.md).
+rest of the [developer documents](docs/index.md).
 
 ## Licensing
 
-See [LICENSE](https://github.com/puppetlabs/puppet/blob/main/LICENSE) file. Puppet is licensed by Puppet, Inc. under the Apache license. Puppet, Inc. can be contacted at: info@puppet.com
+See [LICENSE](LICENSE) file. OpenVox is licensed by Vox Pupuli as a community maintained
+implementation of Puppet. Vox Pupuli can be contacted at: voxpupuli@groups.io.
+Puppet itself is licensed by Puppet, Inc. under the Apache license. Puppet, Inc. can be contacted at: info@puppet.com
 
 ## Support
 
-Please log issues in this project's [GitHub Issues](https://github.com/puppetlabs/puppet/issues). A [mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
-available for asking questions and getting help from others, or if you prefer chat, we also have a [Puppet Community slack.](https://puppetcommunity.slack.com/)
+Please log issues in this project's [GitHub Issues](/issues).
+Other channels for getting help can be found at our
+[support page](https://voxpupuli.org/openvox/support/),
+including the mailing list and other community spaces available
+for asking questions and getting help from others.
+
 
 We use semantic version numbers for our releases and recommend that users stay
 as up-to-date as possible by upgrading to patch releases and minor releases as
@@ -60,9 +59,5 @@ a best-effort basis, until the previous major version is no longer maintained.
 
 For example: If a security vulnerability is discovered in Puppet 8.1.1, we
 would fix it in the 8 series, most likely as 8.1.2. Maintainers would then make
-a best effort to backport that fix onto the latest Puppet 7 release.
-
-Long-term support, including security patches and bug fixes, is available for
-commercial customers. Please see the following page for more details:
-
-[Puppet Enterprise Support Lifecycle](https://puppet.com/docs/puppet-enterprise/product-support-lifecycle/)
+a best effort to backport that fix onto earlier releases that haven't reached
+their respective end-of-life dates.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenVox
 
-OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs
+OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, designed to perform
 administrative tasks (such as adding users, installing packages, and updating server
 configurations) based on a centralized specification.
 

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -81,7 +81,7 @@ class Puppet::Application::Agent < Puppet::Application
   end
 
   def summary
-    _("The puppet agent daemon")
+    _("The puppet agent daemon provided by OpenVox")
   end
 
   def help
@@ -92,7 +92,7 @@ class Puppet::Application::Agent < Puppet::Application
 
       SYNOPSIS
       --------
-      Retrieves the client configuration from the Puppet master and applies it to
+      Retrieves the client configuration from the OpenVox server and applies it to
       the local host.
 
       This service may be run as a daemon, run periodically using cron (or something
@@ -366,7 +366,9 @@ class Puppet::Application::Agent < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -67,8 +67,7 @@ class Puppet::Application::Apply < Puppet::Application
       apply can effectively mimic the catalog that would be served by OpenVox
       server with access to the same modules, although there are some subtle
       differences. When combined with scheduling and an automated system for
-      pushing manifests, this can be used to implement a serverless OpenVox
-      site.
+      pushing manifests, this can be used to implement a serverless site.
 
       Most users should use 'puppet agent' and 'puppet master' for site-wide
       manifests.

--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -36,7 +36,7 @@ class Puppet::Application::Apply < Puppet::Application
   end
 
   def summary
-    _("Apply Puppet manifests locally")
+    _("Apply Puppet manifests locally via OpenVox")
   end
 
   def help
@@ -64,10 +64,10 @@ class Puppet::Application::Apply < Puppet::Application
       individual manifests.
 
       When provided with a modulepath, via command line or config file, puppet
-      apply can effectively mimic the catalog that would be served by puppet
-      master with access to the same modules, although there are some subtle
+      apply can effectively mimic the catalog that would be served by OpenVox
+      server with access to the same modules, although there are some subtle
       differences. When combined with scheduling and an automated system for
-      pushing manifests, this can be used to implement a serverless Puppet
+      pushing manifests, this can be used to implement a serverless OpenVox
       site.
 
       Most users should use 'puppet agent' and 'puppet master' for site-wide
@@ -166,7 +166,9 @@ class Puppet::Application::Apply < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/describe.rb
+++ b/lib/puppet/application/describe.rb
@@ -174,7 +174,7 @@ class Puppet::Application::Describe < Puppet::Application
   option("--meta", "-m")
 
   def summary
-    _("Display help about resource types")
+    _("Display help about resource types available to OpenVox")
   end
 
   def help
@@ -185,7 +185,8 @@ class Puppet::Application::Describe < Puppet::Application
 
       SYNOPSIS
       --------
-      Prints help about Puppet resource types, providers, and metaparameters.
+      Prints help about Puppet resource types, providers, and metaparameters
+      installed on an OpenVox node.
 
 
       USAGE
@@ -225,7 +226,9 @@ class Puppet::Application::Describe < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -110,13 +110,13 @@ class Puppet::Application::Device < Puppet::Application
 
       DESCRIPTION
       -----------
-      Devices require a proxy Puppet agent to request certificates, collect facts,
+      Devices require a proxy OpenVox agent to request certificates, collect facts,
       retrieve and apply catalogs, and store reports.
 
 
       USAGE NOTES
       -----------
-      Devices managed by the puppet-device subcommand on a Puppet agent are
+      Devices managed by the puppet-device subcommand on an OpenVox agent are
       configured in device.conf, which is located at $confdir/device.conf by default,
       and is configurable with the $deviceconfig setting.
 

--- a/lib/puppet/application/device.rb
+++ b/lib/puppet/application/device.rb
@@ -81,7 +81,7 @@ class Puppet::Application::Device < Puppet::Application
   end
 
   def summary
-    _("Manage remote network devices")
+    _("Manage remote network devices via OpenVox")
   end
 
   def help
@@ -92,7 +92,7 @@ class Puppet::Application::Device < Puppet::Application
 
       SYNOPSIS
       --------
-      Retrieves catalogs from the Puppet master and applies them to remote devices.
+      Retrieves catalogs from the OpenVox server and applies them to remote devices.
 
       This subcommand can be run manually; or periodically using cron,
       a scheduled task, or a similar tool.
@@ -222,7 +222,8 @@ class Puppet::Application::Device < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011-2018 Puppet Inc., LLC
+      Copyright (c) 2011-2018 Puppet Inc.,
+      Copyright (c) 2024 Vox Pupuli
       Licensed under the Apache 2.0 License
     HELP
   end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -52,7 +52,7 @@ class Puppet::Application::Doc < Puppet::Application
   end
 
   def summary
-    _("Generate Puppet references")
+    _("Generate Puppet references for OpenVox")
   end
 
   def help
@@ -111,7 +111,9 @@ class Puppet::Application::Doc < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -63,8 +63,7 @@ class Puppet::Application::Doc < Puppet::Application
 
       SYNOPSIS
       --------
-      Generates a reference for all Puppet types. Largely meant for internal
-      Puppet Inc. use. (Deprecated)
+      Generates a reference for all Puppet types. Largely meant for internal use. (Deprecated)
 
 
       USAGE
@@ -78,7 +77,7 @@ class Puppet::Application::Doc < Puppet::Application
       This deprecated command generates a Markdown document to stdout
       describing all installed Puppet types or all allowable arguments to
       puppet executables. It is largely meant for internal use and is used to
-      generate the reference document available on the Puppet Inc. web site.
+      generate the reference documents which can be posted to a website.
 
       For Puppet module documentation (and all other use cases) this command
       has been superseded by the "puppet-strings"

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -16,7 +16,7 @@ class Puppet::Application::Filebucket < Puppet::Application
   attr_reader :args
 
   def summary
-    _("Store and retrieve files in a filebucket")
+    _("Store and retrieve files in an OpenVox filebucket")
   end
 
   def digest_algorithm
@@ -31,7 +31,7 @@ class Puppet::Application::Filebucket < Puppet::Application
 
       SYNOPSIS
       --------
-      A stand-alone Puppet filebucket client.
+      A stand-alone OpenVox filebucket client.
 
 
       USAGE
@@ -207,7 +207,9 @@ class Puppet::Application::Filebucket < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -41,7 +41,7 @@ class Puppet::Application::Filebucket < Puppet::Application
         [-f|--fromdate <date>] [-t|--todate <date>] [-b|--bucket <directory>]
         <file> <file> ...
 
-      Puppet filebucket can operate in three modes, with only one mode per call:
+      This filebucket client can operate in three modes, with only one mode per call:
 
       backup:
         Send one or more files to the specified file bucket. Each sent file is
@@ -120,8 +120,7 @@ class Puppet::Application::Filebucket < Puppet::Application
       * --local:
         Use the local filebucket. This uses the default configuration
         information and the bucket located at the '$clientbucketdir'
-        setting by default. If '--bucket' is set, puppet uses that
-        path instead.
+        setting by default. If '--bucket' is set, that path is used instead.
 
       * --remote:
         Use a remote filebucket. This uses the default configuration

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -101,7 +101,7 @@ class Puppet::Application::Lookup < Puppet::Application
   end
 
   def summary
-    _("Interactive Hiera lookup")
+    _("Interactive Hiera lookup for OpenVox")
   end
 
   def help
@@ -115,8 +115,8 @@ class Puppet::Application::Lookup < Puppet::Application
       Does Hiera lookups from the command line.
 
       Since this command needs access to your Hiera data, make sure to run it on a
-      node that has a copy of that data. This usually means logging into a Puppet
-      Server node and running 'puppet lookup' with sudo.
+      node that has a copy of that data. This usually means logging into an OpenVox
+      server node and running 'puppet lookup' with sudo.
 
       The most common version of this command is:
 
@@ -264,7 +264,9 @@ class Puppet::Application::Lookup < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2015 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
 
     HELP

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -60,7 +60,7 @@ class Puppet::Application::Resource < Puppet::Application
       -----------
       This command provides simple facilities for converting current system
       state into Puppet code, along with some ability to modify the current
-      state using OpenVox's RAL.
+      state using Puppet's RAL.
 
       By default, you must at least provide a type to list, in which case
       puppet resource will tell you everything it knows about all resources of

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -35,7 +35,7 @@ class Puppet::Application::Resource < Puppet::Application
   end
 
   def summary
-    _("The resource abstraction layer shell")
+    _("The OpenVox resource abstraction layer shell")
   end
 
   def help
@@ -46,7 +46,7 @@ class Puppet::Application::Resource < Puppet::Application
 
       SYNOPSIS
       --------
-      Uses the Puppet RAL to directly interact with the system.
+      Uses the OpenVox RAL to directly interact with the system.
 
 
       USAGE
@@ -60,7 +60,7 @@ class Puppet::Application::Resource < Puppet::Application
       -----------
       This command provides simple facilities for converting current system
       state into Puppet code, along with some ability to modify the current
-      state using Puppet's RAL.
+      state using OpenVox's RAL.
 
       By default, you must at least provide a type to list, in which case
       puppet resource will tell you everything it knows about all resources of
@@ -137,7 +137,9 @@ class Puppet::Application::Resource < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2011 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/script.rb
+++ b/lib/puppet/application/script.rb
@@ -107,7 +107,9 @@ class Puppet::Application::Script < Puppet::Application
 
       COPYRIGHT
       ---------
-      Copyright (c) 2017 Puppet Inc., LLC Licensed under the Apache 2.0 License
+      Copyright (c) 2017 Puppet Inc.
+      Copyright (c) 2024 Vox Pupuli
+      Licensed under the Apache 2.0 License
 
     HELP
   end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -17,7 +17,7 @@ class Puppet::Application::Ssl < Puppet::Application
 
       SYNOPSIS
       --------
-      Manage SSL keys and certificates for SSL clients needing
+      Manage SSL keys and certificates for clients needing
       to communicate with an OpenVox infrastructure.
 
       USAGE

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -7,7 +7,7 @@ class Puppet::Application::Ssl < Puppet::Application
   run_mode :agent
 
   def summary
-    _("Manage SSL keys and certificates for puppet SSL clients")
+    _("Manage SSL keys and certificates for OpenVox SSL clients")
   end
 
   def help
@@ -18,7 +18,7 @@ class Puppet::Application::Ssl < Puppet::Application
       SYNOPSIS
       --------
       Manage SSL keys and certificates for SSL clients needing
-      to communicate with a puppet infrastructure.
+      to communicate with an OpenVox infrastructure.
 
       USAGE
       -----
@@ -83,6 +83,12 @@ class Puppet::Application::Ssl < Puppet::Application
 
        * show:
         Print the full-text version of this host's certificate.
+
+      COPYRIGHT
+        ---------
+        Copyright (c) 2011 Puppet Inc.
+        Copyright (c) 2024 Vox Pupuli
+        Licensed under the Apache 2.0 License
     HELP
   end
 

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -3,7 +3,7 @@
 require_relative '../../puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:catalog, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   "Apache 2 license; see COPYING"
 
   summary _("Compile, save, view, and convert catalogs.")

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -5,12 +5,12 @@ require_relative '../../puppet/settings/ini_file'
 
 Puppet::Face.define(:config, '0.0.1') do
   extend Puppet::Util::Colors
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
-  summary _("Interact with Puppet's settings.")
+  summary _("Interact with OpenVox's settings.")
 
-  description "This subcommand can inspect and modify settings from Puppet's
+  description "This subcommand can inspect and modify settings from OpenVox's
     'puppet.conf' configuration file. For documentation about individual settings,
     see https://puppet.com/docs/puppet/latest/configuration.html."
 
@@ -23,7 +23,7 @@ Puppet::Face.define(:config, '0.0.1') do
       The section of the puppet.conf configuration file to interact with.
 
       The three most commonly used sections are 'main', 'server', and 'agent'.
-      'Main' is the default, and is used by all Puppet applications. Other
+      'Main' is the default, and is used by all OpenVox applications. Other
       sections can override 'main' values for specific applications --- the
       'server' section affects Puppet Server, and the 'agent'
       section affects puppet agent.
@@ -37,7 +37,7 @@ Puppet::Face.define(:config, '0.0.1') do
 
   action(:print) do
     summary _("Examine Puppet's current settings.")
-    arguments _("all | <setting> [<setting> ...]")
+    arguments _("all \\| <setting> [<setting> ...]")
     description <<-'EOT'
       Prints the value of a single setting or a list of settings.
 
@@ -56,7 +56,7 @@ Puppet::Face.define(:config, '0.0.1') do
 
       Get a list of important directories from the server's config:
 
-      $ puppet config print all --section server | grep -E "(path|dir)"
+      $ puppet config print all --section server \| grep -E "(path\|dir)"
     EOT
 
     when_invoked do |*args|

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -36,7 +36,7 @@ Puppet::Face.define(:config, '0.0.1') do
   end
 
   action(:print) do
-    summary _("Examine Puppet's current settings.")
+    summary _("Examine OpenVox's current settings.")
     arguments _("all \\| <setting> [<setting> ...]")
     description <<-'EOT'
       Prints the value of a single setting or a list of settings.
@@ -116,7 +116,7 @@ Puppet::Face.define(:config, '0.0.1') do
   end
 
   action(:set) do
-    summary _("Set Puppet's settings.")
+    summary _("Set OpenVox's settings.")
     arguments _("[setting_name] [setting_value]")
     description <<-'EOT'
       Updates values in the `puppet.conf` configuration file.
@@ -199,7 +199,7 @@ Puppet::Face.define(:config, '0.0.1') do
   end
 
   action(:delete) do
-    summary _("Delete a Puppet setting.")
+    summary _("Delete an OpenVox setting.")
     arguments _("<setting>")
     # TRANSLATORS 'main' is a specific section name and should not be translated
     description "Deletes a setting from the specified section. (The default is the section 'main')."

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet/parser/files'
 require_relative '../../puppet/file_system'
 
 Puppet::Face.define(:epp, '0.0.1') do
-  copyright "Puppet Inc.", 2014
+  copyright "Puppet Inc., Vox Pupuli", 2014
   license   _("Apache 2 license; see COPYING")
 
   summary _("Interact directly with the EPP template parser/renderer.")

--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -4,13 +4,13 @@ require_relative '../../puppet/indirector/face'
 require_relative '../../puppet/node/facts'
 
 Puppet::Indirector::Face.define(:facts, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
   summary _("Retrieve and store facts.")
   description <<-'EOT'
     This subcommand manages facts, which are collections of normalized system
-    information used by Puppet. It can read facts directly from the local system
+    information used by OpenVox. It can read facts directly from the local system
     (with the default `facter` terminus).
   EOT
 

--- a/lib/puppet/face/generate.rb
+++ b/lib/puppet/face/generate.rb
@@ -5,7 +5,7 @@ require_relative '../../puppet/generate/type'
 
 # Create the Generate face
 Puppet::Face.define(:generate, '0.1.0') do
-  copyright 'Puppet Inc.', 2016
+  copyright 'Puppet Inc., Vox Pupuli', 2016
   license   _('Apache 2 license; see COPYING')
 
   summary _('Generates Puppet code from Ruby definitions.')

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -10,7 +10,7 @@ Puppet::Face.define(:help, '0.0.1') do
   copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
-  summary _("Display Puppet help.")
+  summary _("Display OpenVox help.")
 
   action(:help) do
     summary _("Display help about OpenVox subcommands and their actions.")

--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -7,13 +7,13 @@ require 'pathname'
 require 'erb'
 
 Puppet::Face.define(:help, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
   summary _("Display Puppet help.")
 
   action(:help) do
-    summary _("Display help about Puppet subcommands and their actions.")
+    summary _("Display help about OpenVox subcommands and their actions.")
     arguments _("[<subcommand>] [<action>]")
     returns _("Short help text for the specified subcommand or action.")
     examples _(<<-'EOT')

--- a/lib/puppet/face/help/global.erb
+++ b/lib/puppet/face/help/global.erb
@@ -13,4 +13,4 @@ Available subcommands:
 
 See 'puppet help <subcommand> <action>' for help on a specific subcommand action.
 See 'puppet help <subcommand>' for help on a specific subcommand.
-Puppet v<%= Puppet.version %>
+OpenVox v<%= Puppet.version %>

--- a/lib/puppet/face/module.rb
+++ b/lib/puppet/face/module.rb
@@ -7,7 +7,7 @@ require_relative '../../puppet/util/colors'
 Puppet::Face.define(:module, '1.0.0') do
   extend Puppet::Util::Colors
 
-  copyright "Puppet Inc.", 2012
+  copyright "Puppet Inc., Vox Pupuli", 2012
   license   _("Apache 2 license; see COPYING")
 
   summary _("Creates, installs and searches for modules on the Puppet Forge.")

--- a/lib/puppet/face/node.rb
+++ b/lib/puppet/face/node.rb
@@ -2,12 +2,12 @@
 
 require_relative '../../puppet/indirector/face'
 Puppet::Indirector::Face.define(:node, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
   summary _("View and manage node definitions.")
   description <<-'EOT'
-    This subcommand interacts with node objects, which are used by Puppet to
+    This subcommand interacts with node objects, which are used by OpenVox to
     build a catalog. A node object consists of the node's facts, environment,
     node parameters (exposed in the parser as top-scope variables), and classes.
   EOT

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -4,7 +4,7 @@ require_relative '../../puppet/face'
 require_relative '../../puppet/parser'
 
 Puppet::Face.define(:parser, '0.0.1') do
-  copyright "Puppet Inc.", 2014
+  copyright "Puppet Inc., Vox Pupuli", 2014
   license   _("Apache 2 license; see COPYING")
 
   summary _("Interact directly with the parser.")
@@ -34,7 +34,7 @@ Puppet::Face.define(:parser, '0.0.1') do
 
       Validate from STDIN:
 
-      $ cat init.pp | puppet parser validate
+      $ cat init.pp \| puppet parser validate
     EOT
     when_invoked do |*args|
       files = args.slice(0..-2)

--- a/lib/puppet/face/plugin.rb
+++ b/lib/puppet/face/plugin.rb
@@ -4,25 +4,25 @@ require_relative '../../puppet/face'
 require_relative '../../puppet/configurer/plugin_handler'
 
 Puppet::Face.define(:plugin, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
-  summary _("Interact with the Puppet plugin system.")
+  summary _("Interact with the OpenVox plugin system.")
   description <<-'EOT'
-    This subcommand provides network access to the puppet master's store of
+    This subcommand provides network access to the OpenVox server's store of
     plugins.
 
-    The puppet master serves Ruby code collected from the `lib` directories
+    The OpenVox server serves Ruby code collected from the `lib` directories
     of its modules. These plugins can be used on agent nodes to extend
     Facter and implement custom types and providers. Plugins are normally
-    downloaded by puppet agent during the course of a run.
+    downloaded by the OpenVox agent during the course of a run.
   EOT
 
   action :download do
     summary _("Download plugins from the puppet master.")
     description <<-'EOT'
-      Downloads plugins from the configured puppet master. Any plugins
-      downloaded in this way will be used in all subsequent Puppet activity.
+      Downloads plugins from the configured OpenVox server. Any plugins
+      downloaded in this way will be used in all subsequent OpenVox activity.
       This action modifies files on disk.
     EOT
     returns _(<<-'EOT')

--- a/lib/puppet/face/report.rb
+++ b/lib/puppet/face/report.rb
@@ -3,7 +3,7 @@
 require_relative '../../puppet/indirector/face'
 
 Puppet::Indirector::Face.define(:report, '0.0.1') do
-  copyright "Puppet Inc.", 2011
+  copyright "Puppet Inc., Vox Pupuli", 2011
   license   _("Apache 2 license; see COPYING")
 
   summary _("Create, display, and submit reports.")
@@ -27,7 +27,7 @@ Puppet::Indirector::Face.define(:report, '0.0.1') do
   action(:submit) do
     summary _("API only: submit a report with error handling.")
     description <<-'EOT'
-      API only: Submits a report to the puppet master. This action is
+      API only: Submits a report to the OpenVox server. This action is
       essentially a shortcut and wrapper for the `save` action with the `rest`
       terminus, and provides additional details in the event of a failure.
     EOT

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1089,12 +1089,12 @@ class Puppet::Settings
   def to_config
     str = %(The configuration file for #{Puppet.run_mode.name}.  Note that this file
 is likely to have unused settings in it; any setting that's
-valid anywhere in Puppet can be in any config file, even if it's not used.
+valid anywhere in OpenVox can be in any config file, even if it's not used.
 
 Every section can specify three special parameters: owner, group, and mode.
 These parameters affect the required permissions of any files specified after
-their specification.  Puppet will sometimes use these parameters to check its
-own configured state, so they can be used to make Puppet a bit more self-managing.
+their specification.  OpenVox will sometimes use these parameters to check its
+own configured state, so they can be used to make OpenVox a bit more self-managing.
 
 The file format supports octothorpe-commented lines, but not partial-line comments.
 
@@ -1142,7 +1142,7 @@ Generated on #{Time.now}.
       begin
         catalog = to_catalog(*sections).to_ral
       rescue => detail
-        Puppet.log_and_raise(detail, "Could not create resources for managing Puppet's files and directories in sections #{sections.inspect}: #{detail}")
+        Puppet.log_and_raise(detail, "Could not create resources for managing OpenVox's files and directories in sections #{sections.inspect}: #{detail}")
       end
 
       catalog.host_config = false

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -175,7 +175,7 @@ module Puppet
             puts colorize(:hred, _("Error: Could not parse application options: invalid option: %{opt}") % { opt: args[0] })
             exit 1
           else
-            puts _("See 'puppet help' for help on available puppet subcommands")
+            puts _("See 'puppet help' for help on available subcommands")
           end
         end
       end
@@ -188,7 +188,7 @@ module Puppet
         end
 
         def run
-          puts colorize(:hred, _("Error: Unknown Puppet subcommand '%{cmd}'") % { cmd: @subcommand_name })
+          puts colorize(:hred, _("Error: Unknown subcommand '%{cmd}'") % { cmd: @subcommand_name })
           super
           exit 1
         end

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -15,7 +15,7 @@ Puppet Enterprise (PE) and open source Puppet share the configuration settings d
 When using boolean settings on the command line, use \fB\-\-setting\fR and \fB\-\-no\-setting\fR instead of \fB\-\-setting (true|false)\fR\. (Using \fB\-\-setting false\fR results in "Error: Could not parse application options: needless argument"\.)
 .
 .IP "\(bu" 4
-Settings can be interpolated as \fB$variables\fR in other settings; \fB$environment\fR is special, in that puppet master will interpolate each agent node\'s environment instead of its own\.
+Settings can be interpolated as \fB$variables\fR in other settings; \fB$environment\fR is special, in that server will interpolate each agent node\'s environment instead of its own\.
 .
 .IP "\(bu" 4
 Multiple values should be specified as comma\-separated lists; multiple directories should be separated with the system path separator (usually a colon)\.
@@ -24,13 +24,13 @@ Multiple values should be specified as comma\-separated lists; multiple director
 Settings that represent time intervals should be specified in duration format: an integer immediately followed by one of the units \'y\' (years of 365 days), \'d\' (days), \'h\' (hours), \'m\' (minutes), or \'s\' (seconds)\. The unit cannot be combined with other units, and defaults to seconds when omitted\. Examples are \'3600\' which is equivalent to \'1h\' (one hour), and \'1825d\' which is equivalent to \'5y\' (5 years)\.
 .
 .IP "\(bu" 4
-If you use the \fBsplay\fR setting, note that the period that it waits changes each time the Puppet agent is restarted\.
+If you use the \fBsplay\fR setting, note that the period that it waits changes each time the agent is restarted\.
 .
 .IP "\(bu" 4
 Settings that take a single file or directory can optionally set the owner, group, and mode for their value: \fBrundir = $vardir/run { owner = puppet, group = puppet, mode = 644 }\fR
 .
 .IP "\(bu" 4
-The Puppet executables ignores any setting that isn\'t relevant to their function\.
+The executables ignore any setting that isn\'t relevant to their function\.
 .
 .IP "" 0
 .
@@ -46,7 +46,7 @@ A lock file to indicate that a puppet agent catalog run is currently in progress
 .IP "" 0
 .
 .SS "agent_disabled_lockfile"
-A lock file to indicate that puppet agent runs have been administratively disabled\. File contains a JSON object with state information\.
+A lock file to indicate that agent runs have been administratively disabled\. File contains a JSON object with state information\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$statedir/agent_disabled\.lock\fR
@@ -62,7 +62,7 @@ Whether to allow a new certificate request to overwrite an existing certificate 
 .IP "" 0
 .
 .SS "allow_pson_serialization"
-Whether to allow PSON serialization\. When unable to serialize to JSON or other formats, Puppet falls back to PSON\. This option affects the configuration management service responses of Puppet Server and the process by which the agent saves its cached catalog\. With a default value of \fBfalse\fR, this option is useful in preventing the loss of data because rich data cannot be serialized via PSON\.
+Whether to allow PSON serialization\. When unable to serialize to JSON or other formats, OpenVox falls back to PSON\. This option affects the configuration management service responses of the server and the process by which the agent saves its cached catalog\. With a default value of \fBfalse\fR, this option is useful in preventing the loss of data because rich data cannot be serialized via PSON\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -70,7 +70,7 @@ Whether to allow PSON serialization\. When unable to serialize to JSON or other 
 .IP "" 0
 .
 .SS "always_retry_plugins"
-Affects how we cache attempts to load Puppet resource types and features\. If true, then calls to \fBPuppet\.type\.<type>?\fR \fBPuppet\.feature\.<feature>?\fR will always attempt to load the type or feature (which can be an expensive operation) unless it has already been loaded successfully\. This makes it possible for a single agent run to, e\.g\., install a package that provides the underlying capabilities for a type or feature, and then later load that type or feature during the same run (even if the type or feature had been tested earlier and had not been available)\.
+Affects how we cache attempts to load resource types and features\. If true, then calls to \fBPuppet\.type\.<type>?\fR \fBPuppet\.feature\.<feature>?\fR will always attempt to load the type or feature (which can be an expensive operation) unless it has already been loaded successfully\. This makes it possible for a single agent run to, e\.g\., install a package that provides the underlying capabilities for a type or feature, and then later load that type or feature during the same run (even if the type or feature had been tested earlier and had not been available)\.
 .
 .P
 If this setting is set to false, then types and features will only be checked once, and if they are not available, the negative result is cached and returned for all subsequent attempts to load the type or feature\. This behavior is almost always appropriate for the server, and can result in a significant performance improvement for types and features that are checked frequently\.
@@ -89,16 +89,16 @@ Whether log files should always flush to disk\.
 .IP "" 0
 .
 .SS "autosign"
-Whether (and how) to autosign certificate requests\. This setting is only relevant on a Puppet Server acting as a certificate authority (CA)\.
+Whether (and how) to autosign certificate requests\. This setting is only relevant on a server acting as a certificate authority (CA)\.
 .
 .P
 Valid values are true (autosigns all certificate requests; not recommended), false (disables autosigning certificates), or the absolute path to a file\.
 .
 .P
-The file specified in this setting may be either a \fBconfiguration file\fR or a \fBcustom policy executable\.\fR Puppet will automatically determine what it is: If the Puppet user (see the \fBuser\fR setting) can execute the file, it will be treated as a policy executable; otherwise, it will be treated as a config file\.
+The file specified in this setting may be either a \fBconfiguration file\fR or a \fBcustom policy executable\.\fR OpenVox will automatically determine what it is: If the OpenVox user (see the \fBuser\fR setting) can execute the file, it will be treated as a policy executable; otherwise, it will be treated as a config file\.
 .
 .P
-If a custom policy executable is configured, the CA Puppet Server will run it every time it receives a CSR\. The executable will be passed the subject CN of the request \fIas a command line argument,\fR and the contents of the CSR in PEM format \fIon stdin\.\fR It should exit with a status of 0 if the cert should be autosigned and non\-zero if the cert should not be autosigned\.
+If a custom policy executable is configured, the CA Server will run it every time it receives a CSR\. The executable will be passed the subject CN of the request \fIas a command line argument,\fR and the contents of the CSR in PEM format \fIon stdin\.\fR It should exit with a status of 0 if the cert should be autosigned and non\-zero if the cert should not be autosigned\.
 .
 .P
 If a certificate request is not autosigned, it will persist for review\. An admin user can use the \fBpuppetserver ca sign\fR command to manually sign it, or can delete the request\.
@@ -123,7 +123,7 @@ These are the modules that will be used by \fIall\fR environments\. Note that th
 .IP "" 0
 .
 .SS "binder_config"
-The binder configuration file\. Puppet reads this file on each request to configure the bindings system\. If set to nil (the default), a $confdir/binder_config\.yaml is optionally loaded\. If it does not exists, a default configuration is used\. If the setting :binding_config is specified, it must reference a valid and existing yaml file\.
+The binder configuration file\. OpenVox reads this file on each request to configure the bindings system\. If set to nil (the default), a $confdir/binder_config\.yaml is optionally loaded\. If it does not exists, a default configuration is used\. If the setting :binding_config is specified, it must reference a valid and existing yaml file\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: ``
@@ -163,7 +163,7 @@ The port to use for the certificate authority\.
 .IP "" 0
 .
 .SS "ca_refresh_interval"
-How often the Puppet agent refreshes its local CA certificates\. By default, CA certificates are refreshed every 24 hours\. If a different interval is specified, the agent refreshes its CA certificates during the next agent run if the elapsed time since the certificates were last refreshed exceeds the specified duration\.
+How often the agent refreshes its local CA certificates\. By default, CA certificates are refreshed every 24 hours\. If a different interval is specified, the agent refreshes its CA certificates during the next agent run if the elapsed time since the certificates were last refreshed exceeds the specified duration\.
 .
 .P
 In general, the interval should be greater than the \fBruninterval\fR value\. Setting the \fBca_refresh_interval\fR value to 0 or an equal or lesser value than \fBruninterval\fR causes the CA certificates to be refreshed on every run\.
@@ -268,16 +268,16 @@ The certificate directory\.
 Whether certificate revocation checking should be enabled, and what level of checking should be performed\.
 .
 .P
-When certificate revocation is enabled, Puppet expects the contents of its CRL to be one or more PEM\-encoded CRLs concatenated together\. When using a cert bundle, CRLs for all CAs in the chain of trust must be included in the crl file\. The chain should be ordered from least to most authoritative, with the first CRL listed being for the root of the chain and the last being for the leaf CA\.
+When certificate revocation is enabled, OpenVox expects the contents of its CRL to be one or more PEM\-encoded CRLs concatenated together\. When using a cert bundle, CRLs for all CAs in the chain of trust must be included in the crl file\. The chain should be ordered from least to most authoritative, with the first CRL listed being for the root of the chain and the last being for the leaf CA\.
 .
 .P
-When certificate_revocation is set to \'true\' or \'chain\', Puppet ensures that each CA in the chain of trust has not been revoked by its issuing CA\.
+When certificate_revocation is set to \'true\' or \'chain\', OpenVox ensures that each CA in the chain of trust has not been revoked by its issuing CA\.
 .
 .P
-When certificate_revocation is set to \'leaf\', Puppet verifies certs against the issuing CA\'s revocation list, but it does not verify the revocation status of the issuing CA or any CA above it within the chain of trust\.
+When certificate_revocation is set to \'leaf\', OpenVox verifies certs against the issuing CA\'s revocation list, but it does not verify the revocation status of the issuing CA or any CA above it within the chain of trust\.
 .
 .P
-When certificate_revocation is set to \'false\', Puppet disables all certificate revocation checking and does not attempt to download the CRL\.
+When certificate_revocation is set to \'false\', OpenVox disables all certificate revocation checking and does not attempt to download the CRL\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBchain\fR
@@ -285,13 +285,13 @@ When certificate_revocation is set to \'false\', Puppet disables all certificate
 .IP "" 0
 .
 .SS "certname"
-The name to use when handling certificates\. When a node requests a certificate from the CA Puppet Server, it uses the value of the \fBcertname\fR setting as its requested Subject CN\.
+The name to use when handling certificates\. When a node requests a certificate from the CA Server, it uses the value of the \fBcertname\fR setting as its requested Subject CN\.
 .
 .P
-This is the name used when managing a node\'s permissions in Puppet Server\'s auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\. In most cases, it is also used as the node\'s name when matching node definitions \fIhttps://puppet\.com/docs/puppet/latest/lang_node_definitions\.html\fR and requesting data from an ENC\. (This can be changed with the \fBnode_name_value\fR and \fBnode_name_fact\fR settings, although you should only do so if you have a compelling reason\.)
+This is the name used when managing a node\'s permissions in the Server\'s auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\. In most cases, it is also used as the node\'s name when matching node definitions \fIhttps://puppet\.com/docs/puppet/latest/lang_node_definitions\.html\fR and requesting data from an ENC\. (This can be changed with the \fBnode_name_value\fR and \fBnode_name_fact\fR settings, although you should only do so if you have a compelling reason\.)
 .
 .P
-A node\'s certname is available in Puppet manifests as \fB$trusted[\'certname\']\fR\. (See Facts and Built\-In Variables \fIhttps://puppet\.com/docs/puppet/latest/lang_facts_and_builtin_vars\.html\fR for more details\.)
+A node\'s certname is available in manifests as \fB$trusted[\'certname\']\fR\. (See Facts and Built\-In Variables \fIhttps://puppet\.com/docs/puppet/latest/lang_facts_and_builtin_vars\.html\fR for more details\.)
 .
 .IP "\(bu" 4
 For best compatibility, you should limit the value of \fBcertname\fR to only use lowercase letters, numbers, periods, underscores, and dashes\. (That is, it should match \fB/A[a\-z0\-9\._\-]+Z/\fR\.)
@@ -313,7 +313,7 @@ Defaults to the node\'s fully qualified domain name\.
 .IP "" 0
 .
 .SS "ciphers"
-The list of ciphersuites for TLS connections initiated by puppet\. The default value is chosen to support TLS 1\.0 and up, but can be made more restrictive if needed\. The ciphersuites must be specified in OpenSSL format, not IANA\.
+The list of ciphersuites for TLS connections initiated by OpenVox\. The default value is chosen to support TLS 1\.0 and up, but can be made more restrictive if needed\. The ciphersuites must be specified in OpenSSL format, not IANA\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBECDHE\-ECDSA\-AES128\-GCM\-SHA256:ECDHE\-RSA\-AES128\-GCM\-SHA256:ECDHE\-ECDSA\-AES256\-GCM\-SHA384:ECDHE\-RSA\-AES256\-GCM\-SHA384:ECDHE\-ECDSA\-CHACHA20\-POLY1305:ECDHE\-RSA\-CHACHA20\-POLY1305:DHE\-RSA\-AES128\-GCM\-SHA256:DHE\-RSA\-AES256\-GCM\-SHA384:DHE\-RSA\-CHACHA20\-POLY1305:ECDHE\-ECDSA\-AES128\-SHA256:ECDHE\-RSA\-AES128\-SHA256:ECDHE\-ECDSA\-AES128\-SHA:ECDHE\-RSA\-AES128\-SHA:ECDHE\-ECDSA\-AES256\-SHA384:ECDHE\-RSA\-AES256\-SHA384:ECDHE\-ECDSA\-AES256\-SHA:ECDHE\-RSA\-AES256\-SHA:DHE\-RSA\-AES128\-SHA256:DHE\-RSA\-AES256\-SHA256:AES128\-GCM\-SHA256:AES256\-GCM\-SHA384:AES128\-SHA256:AES256\-SHA256\fR
@@ -321,7 +321,7 @@ The list of ciphersuites for TLS connections initiated by puppet\. The default v
 .IP "" 0
 .
 .SS "classfile"
-The file in which puppet agent stores a list of the classes associated with the retrieved configuration\. Can be loaded in the separate \fBpuppet\fR executable using the \fB\-\-loadclasses\fR option\.
+The file in which the agent stores a list of the classes associated with the retrieved configuration\. Can be loaded in the separate \fBpuppet\fR executable using the \fB\-\-loadclasses\fR option\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$statedir/classes\.txt\fR
@@ -353,10 +353,10 @@ The directory in which client\-side YAML data is stored\.
 .IP "" 0
 .
 .SS "code"
-Code to parse directly\. This is essentially only used by \fBpuppet\fR, and should only be set if you\'re writing your own Puppet executable\.
+Code to parse directly\. This is essentially only used by \fBOpenVox\fR, and should only be set if you\'re writing your own executable\.
 .
 .SS "codedir"
-The main Puppet code directory\. The default for this setting is calculated based on the user\. If the process is running as root or the user that Puppet is supposed to run as, it defaults to a system directory, but if it\'s running as any other user, it defaults to being in the user\'s home directory\.
+The main code directory\. The default for this setting is calculated based on the user\. If the process is running as root or the user that OpenVox is supposed to run as, it defaults to a system directory, but if it\'s running as any other user, it defaults to being in the user\'s home directory\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBUnix/Linux: /etc/puppetlabs/code \-\- Windows: C:\eProgramData\ePuppetLabs\ecode \-\- Non\-root user: ~/\.puppetlabs/etc/code\fR
@@ -372,7 +372,7 @@ Whether to use colors when logging to the console\. Valid values are \fBansi\fR 
 .IP "" 0
 .
 .SS "confdir"
-The main Puppet configuration directory\. The default for this setting is calculated based on the user\. If the process is running as root or the user that Puppet is supposed to run as, it defaults to a system directory, but if it\'s running as any other user, it defaults to being in the user\'s home directory\.
+The main configuration directory\. The default for this setting is calculated based on the user\. If the process is running as root or the user that OpenVox is supposed to run as, it defaults to a system directory, but if it\'s running as any other user, it defaults to being in the user\'s home directory\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBUnix/Linux: /etc/puppetlabs/puppet \-\- Windows: C:\eProgramData\ePuppetLabs\epuppet\eetc \-\- Non\-root user: ~/\.puppetlabs/etc/puppet\fR
@@ -388,7 +388,7 @@ The configuration file for the current puppet application\.
 .IP "" 0
 .
 .SS "config_file_name"
-The name of the puppet config file\.
+The name of the OpenVox config file\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet\.conf\fR
@@ -405,7 +405,7 @@ Setting a global value for config_version in puppet\.conf is not allowed (but it
 Prints the value of a specific configuration setting\. If the name of a setting is provided for this, then the value is printed and puppet exits\. Comma\-separate multiple values\. For a list of all values, specify \'all\'\. This setting is deprecated, the \'puppet config\' command replaces this functionality\.
 .
 .SS "crl_refresh_interval"
-How often the Puppet agent refreshes its local Certificate Revocation List (CRL)\. By default, the CRL is refreshed every 24 hours\. If a different interval is specified, the agent refreshes its CRL on the next Puppet agent run if the elapsed time since the CRL was last refreshed exceeds the specified interval\.
+How often the agent refreshes its local Certificate Revocation List (CRL)\. By default, the CRL is refreshed every 24 hours\. If a different interval is specified, the agent refreshes its CRL on the next agent run if the elapsed time since the CRL was last refreshed exceeds the specified interval\.
 .
 .P
 In general, the interval should be greater than the \fBruninterval\fR value\. Setting the \fBcrl_refresh_interval\fR value to 0 or an equal or lesser value than \fBruninterval\fR causes the CRL to be refreshed on every run\.
@@ -419,7 +419,7 @@ If the agent downloads a new CRL, the agent will use it for subsequent network r
 .IP "" 0
 .
 .SS "csr_attributes"
-An optional file containing custom attributes to add to certificate signing requests (CSRs)\. You should ensure that this file does not exist on your CA Puppet Server; if it does, unwanted certificate extensions may leak into certificates created with the \fBpuppetserver ca generate\fR command\.
+An optional file containing custom attributes to add to certificate signing requests (CSRs)\. You should ensure that this file does not exist on your CA Server; if it does, unwanted certificate extensions may leak into certificates created with the \fBpuppetserver ca generate\fR command\.
 .
 .P
 If present, this file must be a YAML hash containing a \fBcustom_attributes\fR key and/or an \fBextension_requests\fR key\. The value of each key must be a hash, where each key is a valid OID and each value is an object that can be cast to a string\.
@@ -444,7 +444,7 @@ Where the CA stores certificate requests\.
 .IP "" 0
 .
 .SS "daemonize"
-Whether to send the process into the background\. This defaults to true on POSIX systems, and to false on Windows (where Puppet currently cannot daemonize)\.
+Whether to send the process into the background\. This defaults to true on POSIX systems, and to false on Windows (where OpenVox currently cannot daemonize)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBtrue\fR
@@ -471,7 +471,7 @@ The default source for files if no server is given in a uri, e\.g\. puppet:///fi
 The default main manifest for directory environments\. Any environment that doesn\'t set the \fBmanifest\fR setting in its \fBenvironment\.conf\fR file will use this manifest\.
 .
 .P
-This setting\'s value can be an absolute or relative path\. An absolute path will make all environments default to the same main manifest; a relative path will allow each environment to use its own manifest, and Puppet will resolve the path relative to each environment\'s main directory\.
+This setting\'s value can be an absolute or relative path\. An absolute path will make all environments default to the same main manifest; a relative path will allow each environment to use its own manifest, and OpenVox will resolve the path relative to each environment\'s main directory\.
 .
 .P
 In either case, the path can point to a single file or to a directory of manifests to be evaluated in alphabetical order\.
@@ -514,7 +514,7 @@ The root directory of devices\' $vardir\.
 .IP "" 0
 .
 .SS "diff"
-Which diff command to use when printing differences between files\. This setting has no default value on Windows, as standard \fBdiff\fR is not available, but Puppet can use many third\-party diff tools\.
+Which diff command to use when printing differences between files\. This setting has no default value on Windows, as standard \fBdiff\fR is not available, but OpenVox can use many third\-party diff tools\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBdiff\fR
@@ -538,7 +538,7 @@ Which digest algorithm to use for file resources and the filebucket\. Valid valu
 .IP "" 0
 .
 .SS "disable_i18n"
-If true, turns off all translations of Puppet and module log messages, which affects error, warning, and info log messages, as well as any translations in the report and CLI\.
+If true, turns off all translations of OpenVox and module log messages, which affects error, warning, and info log messages, as well as any translations in the report and CLI\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBtrue\fR
@@ -546,7 +546,7 @@ If true, turns off all translations of Puppet and module log messages, which aff
 .IP "" 0
 .
 .SS "disable_per_environment_manifest"
-Whether to disallow an environment\-specific main manifest\. When set to \fBtrue\fR, Puppet will use the manifest specified in the \fBdefault_manifest\fR setting for all environments\. If an environment specifies a different main manifest in its \fBenvironment\.conf\fR file, catalog requests for that environment will fail with an error\.
+Whether to disallow an environment\-specific main manifest\. When set to \fBtrue\fR, OpenVox will use the manifest specified in the \fBdefault_manifest\fR setting for all environments\. If an environment specifies a different main manifest in its \fBenvironment\.conf\fR file, catalog requests for that environment will fail with an error\.
 .
 .P
 This setting requires \fBdefault_manifest\fR to be set to an absolute path\.
@@ -557,10 +557,10 @@ This setting requires \fBdefault_manifest\fR to be set to an absolute path\.
 .IP "" 0
 .
 .SS "disable_warnings"
-A comma\-separated list of warning types to suppress\. If large numbers of warnings are making Puppet\'s logs too large or difficult to use, you can temporarily silence them with this setting\.
+A comma\-separated list of warning types to suppress\. If large numbers of warnings are making OpenVox\'s logs too large or difficult to use, you can temporarily silence them with this setting\.
 .
 .P
-If you are preparing to upgrade Puppet to a new major version, you should re\-enable all warnings for a while\.
+If you are preparing to upgrade OpenVox to a new major version, you should re\-enable all warnings for a while\.
 .
 .P
 Valid values for this setting are:
@@ -580,16 +580,16 @@ Valid values for this setting are:
 .IP "" 0
 .
 .SS "dns_alt_names"
-A comma\-separated list of alternate DNS names for Puppet Server\. These are extra hostnames (in addition to its \fBcertname\fR) that the server is allowed to use when serving agents\. Puppet checks this setting when automatically creating a certificate for Puppet agent or Puppet Server\. These can be either IP or DNS, and the type should be specified and followed with a colon\. Untyped inputs will default to DNS\.
+A comma\-separated list of alternate DNS names for OpenVox Server\. These are extra hostnames (in addition to its \fBcertname\fR) that the server is allowed to use when serving agents\. OpenVox checks this setting when automatically creating a certificate for the agent or the Server\. These can be either IP or DNS, and the type should be specified and followed with a colon\. Untyped inputs will default to DNS\.
 .
 .P
-In order to handle agent requests at a given hostname (like "puppet\.example\.com"), Puppet Server needs a certificate that proves it\'s allowed to use that name; if a server shows a certificate that doesn\'t include its hostname, Puppet agents will refuse to trust it\. If you use a single hostname for Puppet traffic but load\-balance it to multiple Puppet Servers, each of those servers needs to include the official hostname in its list of extra names\.
+In order to handle agent requests at a given hostname (like "puppet\.example\.com"), OpenVox Server needs a certificate that proves it\'s allowed to use that name; if a server shows a certificate that doesn\'t include its hostname, agents will refuse to trust it\. If you use a single hostname for OpenVox traffic but load\-balance it to multiple servers, each of those servers needs to include the official hostname in its list of extra names\.
 .
 .P
 \fBNote:\fR The list of alternate names is locked in when the server\'s certificate is signed\. If you need to change the list later, you can\'t just change this setting; you also need to regenerate the certificate\. For more information on that process, see the cert regen docs \fIhttps://puppet\.com/docs/puppet/latest/ssl_regenerate_certificates\.html\fR\.
 .
 .P
-To see all the alternate names your servers are using, log into your CA server and run \fBpuppetserver ca list \-\-all\fR, then check the output for \fB(alt names: \.\.\.)\fR\. Most agent nodes should NOT have alternate names; the only certs that should have them are Puppet Server nodes that you want other agents to trust\.
+To see all the alternate names your servers are using, log into your CA server and run \fBpuppetserver ca list \-\-all\fR, then check the output for \fB(alt names: \.\.\.)\fR\. Most agent nodes should NOT have alternate names; the only certs that should have them are Server nodes that you want other agents to trust\.
 .
 .SS "document_all"
 Whether to document all resources when using \fBpuppet doc\fR to generate manifest documentation\.
@@ -600,13 +600,13 @@ Whether to document all resources when using \fBpuppet doc\fR to generate manife
 .IP "" 0
 .
 .SS "environment"
-The environment in which Puppet is running\. For clients, such as \fBpuppet agent\fR, this determines the environment itself, which Puppet uses to find modules and much more\. For servers, such as \fBpuppet server\fR, this provides the default environment for nodes that Puppet knows nothing about\.
+The environment in which OpenVox is running\. For clients, such as \fBOpenVox agent\fR, this determines the environment itself, which OpenVox uses to find modules and much more\. For servers, such as \fBOpenVox server\fR, this provides the default environment for nodes that OpenVox knows nothing about\.
 .
 .P
-When defining an environment in the \fB[agent]\fR section, this refers to the environment that the agent requests from the primary server\. The environment doesn\'t have to exist on the local filesystem because the agent fetches it from the primary server\. This definition is used when running \fBpuppet agent\fR\.
+When defining an environment in the \fB[agent]\fR section, this refers to the environment that the agent requests from the primary server\. The environment doesn\'t have to exist on the local filesystem because the agent fetches it from the primary server\. This definition is used when running \fBOpenVox agent\fR\.
 .
 .P
-When defined in the \fB[user]\fR section, the environment refers to the path that Puppet uses to search for code and modules related to its execution\. This requires the environment to exist locally on the filesystem where puppet is being executed\. Puppet subcommands, including \fBpuppet module\fR and \fBpuppet apply\fR, use this definition\.
+When defined in the \fB[user]\fR section, the environment refers to the path that OpenVox uses to search for code and modules related to its execution\. This requires the environment to exist locally on the filesystem where OpenVox is being executed\. OpenVox subcommands, including \fBpuppet module\fR and \fBpuppet apply\fR, use this definition\.
 .
 .P
 Given that the context and effects vary depending on the config section \fIhttps://puppet\.com/docs/puppet/latest/config_file_main\.html#config\-sections\fR in which the \fBenvironment\fR setting is defined, do not set it globally\.
@@ -625,16 +625,16 @@ The name of a registered environment data provider used when obtaining environme
 .IP "" 0
 .
 .SS "environment_timeout"
-How long the Puppet server should cache data it loads from an environment\.
+How long the server should cache data it loads from an environment\.
 .
 .P
-A value of \fB0\fR will disable caching\. This setting can also be set to \fBunlimited\fR, which will cache environments until the server is restarted or told to refresh the cache\. All other values will result in Puppet server evicting environments that haven\'t been used within the last \fBenvironment_timeout\fR seconds\.
+A value of \fB0\fR will disable caching\. This setting can also be set to \fBunlimited\fR, which will cache environments until the server is restarted or told to refresh the cache\. All other values will result in the server evicting environments that haven\'t been used within the last \fBenvironment_timeout\fR seconds\.
 .
 .P
-You should change this setting once your Puppet deployment is doing non\-trivial work\. We chose the default value of \fB0\fR because it lets new users update their code without any extra steps, but it lowers the performance of your Puppet server\. We recommend either:
+You should change this setting once your deployment is doing non\-trivial work\. We chose the default value of \fB0\fR because it lets new users update their code without any extra steps, but it lowers the performance of your server\. We recommend either:
 .
 .IP "\(bu" 4
-Setting this to \fBunlimited\fR and explicitly refreshing your Puppet server as part of your code deployment process\.
+Setting this to \fBunlimited\fR and explicitly refreshing your server as part of your code deployment process\.
 .
 .IP "\(bu" 4
 Setting this to a number that will keep your most actively used environments cached, but allow testing environments to fall out of the cache and reduce memory usage\. A value of 3 minutes (3m) is a reasonable value\.
@@ -642,7 +642,7 @@ Setting this to a number that will keep your most actively used environments cac
 .IP "" 0
 .
 .P
-Once you set \fBenvironment_timeout\fR to a non\-zero value, you need to tell Puppet server to read new code from disk using the \fBenvironment\-cache\fR API endpoint after you deploy new code\. See the docs for the Puppet Server administrative API \fIhttps://puppet\.com/docs/puppetserver/latest/admin\-api/v1/environment\-cache\.html\fR\.
+Once you set \fBenvironment_timeout\fR to a non\-zero value, you need to tell the server to read new code from disk using the \fBenvironment\-cache\fR API endpoint after you deploy new code\. See the docs for the OpenVox Server administrative API \fIhttps://puppet\.com/docs/puppetserver/latest/admin\-api/v1/environment\-cache\.html\fR\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB0\fR
@@ -677,7 +677,7 @@ Specifies how unchanged resources are listed in reports\. When set to \fBtrue\fR
 .IP "" 0
 .
 .SS "external_nodes"
-The external node classifier (ENC) script to use for node data\. Puppet combines this data with the main manifest to produce node catalogs\.
+The external node classifier (ENC) script to use for node data\. OpenVox combines this data with the main manifest to produce node catalogs\.
 .
 .P
 To enable this setting, set the \fBnode_terminus\fR setting to \fBexec\fR\.
@@ -736,7 +736,7 @@ The soft limit for the length of a fact value\.
 .IP "" 0
 .
 .SS "factpath"
-Where Puppet should look for facts\. Multiple directories should be separated by the system path separator character\. (The POSIX path separator is \':\', and the Windows path separator is \';\'\.)
+Where OpenVox should look for facts\. Multiple directories should be separated by the system path separator character\. (The POSIX path separator is \':\', and the Windows path separator is \';\'\.)
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$vardir/lib/facter:$vardir/facts\fR
@@ -760,7 +760,7 @@ Where the fileserver configuration is stored\.
 .IP "" 0
 .
 .SS "filetimeout"
-The minimum time to wait between checking for updates in configuration files\. This timeout determines how quickly Puppet checks whether a file (such as manifests or puppet\.conf) has changed on disk\. The default will change in a future release to be \'unlimited\', requiring a reload of the Puppet service to pick up changes to its internal configuration\. Currently we do not accept a value of \'unlimited\'\. To reparse files within an environment in Puppet Server please use the environment_cache endpoint
+The minimum time to wait between checking for updates in configuration files\. This timeout determines how quickly OpenVox checks whether a file (such as manifests or puppet\.conf) has changed on disk\. The default will change in a future release to be \'unlimited\', requiring a reload of the OpenVox service to pick up changes to its internal configuration\. Currently we do not accept a value of \'unlimited\'\. To reparse files within an environment in the server please use the environment_cache endpoint
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB15s\fR
@@ -768,7 +768,7 @@ The minimum time to wait between checking for updates in configuration files\. T
 .IP "" 0
 .
 .SS "forge_authorization"
-The authorization key to connect to the Puppet Forge\. Leave blank for unauthorized or license based connections
+The authorization key to connect to the The Forge\. Leave blank for unauthorized or license based connections
 .
 .IP "\(bu" 4
 \fIDefault\fR: ``
@@ -784,7 +784,7 @@ Freezes the \'main\' class, disallowing any code to be added to it\. This essent
 .IP "" 0
 .
 .SS "genconfig"
-When true, causes Puppet applications to print an example config file to stdout and exit\. The example will include descriptions of each setting, and the current (or default) value of each setting, incorporating any settings overridden on the CLI (with the exception of \fBgenconfig\fR itself)\. This setting only makes sense when specified on the command line as \fB\-\-genconfig\fR\.
+When true, causes OpenVox applications to print an example config file to stdout and exit\. The example will include descriptions of each setting, and the current (or default) value of each setting, incorporating any settings overridden on the CLI (with the exception of \fBgenconfig\fR itself)\. This setting only makes sense when specified on the command line as \fB\-\-genconfig\fR\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -800,13 +800,13 @@ Whether to just print a manifest to stdout and exit\. Only makes sense when spec
 .IP "" 0
 .
 .SS "graph"
-Whether to create \.dot graph files, which let you visualize the dependency and containment relationships in Puppet\'s catalog\. You can load and view these files with tools like OmniGraffle \fIhttp://www\.omnigroup\.com/applications/omnigraffle/\fR (OS X) or graphviz \fIhttp://www\.graphviz\.org/\fR (multi\-platform)\.
+Whether to create \.dot graph files, which let you visualize the dependency and containment relationships in OpenVox\'s catalog\. You can load and view these files with tools like OmniGraffle \fIhttp://www\.omnigroup\.com/applications/omnigraffle/\fR (OS X) or graphviz \fIhttp://www\.graphviz\.org/\fR (multi\-platform)\.
 .
 .P
 Graph files are created when \fIapplying\fR a catalog, so this setting should be used on nodes running \fBpuppet agent\fR or \fBpuppet apply\fR\.
 .
 .P
-The \fBgraphdir\fR setting determines where Puppet will save graphs\. Note that we don\'t save graphs for historical runs; Puppet will replace the previous \.dot files with new ones every time it applies a catalog\.
+The \fBgraphdir\fR setting determines where OpenVox will save graphs\. Note that we don\'t save graphs for historical runs; OpenVox will replace the previous \.dot files with new ones every time it applies a catalog\.
 .
 .P
 See your graphing software\'s documentation for details on opening \.dot files\. If you\'re using GraphViz\'s \fBdot\fR command, you can do a quick PNG render with \fBdot \-Tpng <DOT FILE> \-o <OUTPUT FILE>\fR\.
@@ -825,7 +825,7 @@ Where to save \.dot\-format graphs (when the \fBgraph\fR setting is enabled)\.
 .IP "" 0
 .
 .SS "group"
-The group Puppet Server will run as\. Used to ensure the agent side processes (agent, apply, etc) create files and directories readable by Puppet Server when necessary\.
+The group OpenVox Server will run as\. Used to ensure the agent side processes (agent, apply, etc) create files and directories readable by OpenVox Server when necessary\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet\fR
@@ -833,10 +833,10 @@ The group Puppet Server will run as\. Used to ensure the agent side processes (a
 .IP "" 0
 .
 .SS "hiera_config"
-The hiera configuration file\. Puppet only reads this file on startup, so you must restart the puppet server every time you edit it\.
+The hiera configuration file\. OpenVox only reads this file on startup, so you must restart the server every time you edit it\.
 .
 .IP "\(bu" 4
-\fIDefault\fR: \fB$confdir/hiera\.yaml\. However, for backwards compatibility, if a file exists at $codedir/hiera\.yaml, Puppet uses that instead\.\fR
+\fIDefault\fR: \fB$confdir/hiera\.yaml\. However, for backwards compatibility, if a file exists at $codedir/hiera\.yaml, OpenVox uses that instead\.\fR
 .
 .IP "" 0
 .
@@ -849,7 +849,7 @@ Where individual hosts store and look for their certificates\.
 .IP "" 0
 .
 .SS "hostcert_renewal_interval"
-How often the Puppet agent renews its client certificate\. By default, the client certificate is renewed 30 days before the certificate expires\. If a different interval is specified, the agent renews its client certificate during the next agent run, assuming that the client certificate has expired within the specified duration\.
+How often the agent renews its client certificate\. By default, the client certificate is renewed 30 days before the certificate expires\. If a different interval is specified, the agent renews its client certificate during the next agent run, assuming that the client certificate has expired within the specified duration\.
 .
 .P
 In general, the \fBhostcert_renewal_interval\fR value should be greater than the \fBruninterval\fR value\. Setting the \fBhostcert_renewal_interval\fR value to 0 disables automatic renewal\.
@@ -978,7 +978,7 @@ The HTTP User\-Agent string to send when making network requests\.
 .IP "" 0
 .
 .SS "ignore_plugin_errors"
-Whether the puppet run should ignore errors during pluginsync\. If the setting is false and there are errors during pluginsync, then the agent will abort the run and submit a report containing information about the failed run\.
+Whether the run should ignore errors during pluginsync\. If the setting is false and there are errors during pluginsync, then the agent will abort the run and submit a report containing information about the failed run\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -994,7 +994,7 @@ Skip searching for classes and definitions that were missing during a prior comp
 .IP "" 0
 .
 .SS "ignoreschedules"
-Boolean; whether puppet agent should ignore schedules\. This is useful for initial puppet agent runs\.
+Boolean; whether the agent should ignore schedules\. This is useful for initial agent runs\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1002,7 +1002,7 @@ Boolean; whether puppet agent should ignore schedules\. This is useful for initi
 .IP "" 0
 .
 .SS "include_legacy_facts"
-Whether to include legacy facts when requesting a catalog\. This option can be set to \fBfalse\fR if all puppet manifests, hiera\.yaml, and hiera configuration layers no longer access legacy facts, such as \fB$osfamily\fR, and instead access structured facts, such as \fB$facts[\'os\'][\'family\']\fR\.
+Whether to include legacy facts when requesting a catalog\. This option can be set to \fBfalse\fR if all manifests, hiera\.yaml, and hiera configuration layers no longer access legacy facts, such as \fB$osfamily\fR, and instead access structured facts, such as \fB$facts[\'os\'][\'family\']\fR\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1026,7 +1026,7 @@ The bit length of keys\.
 .IP "" 0
 .
 .SS "lastrunfile"
-Where puppet agent stores the last run report summary in yaml format\.
+Where the agent stores the last run report summary in yaml format\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$publicdir/last_run_summary\.yaml\fR
@@ -1034,7 +1034,7 @@ Where puppet agent stores the last run report summary in yaml format\.
 .IP "" 0
 .
 .SS "lastrunreport"
-Where Puppet Agent stores the last run report, by default, in yaml format\. The format of the report can be changed by setting the \fBcache\fR key of the \fBreport\fR terminus in the routes\.yaml \fIhttps://puppet\.com/docs/puppet/latest/config_file_routes\.html\fR file\. To avoid mismatches between content and file extension, this setting needs to be manually updated to reflect the terminus changes\.
+Where thre agent stores the last run report, by default, in yaml format\. The format of the report can be changed by setting the \fBcache\fR key of the \fBreport\fR terminus in the routes\.yaml \fIhttps://puppet\.com/docs/puppet/latest/config_file_routes\.html\fR file\. To avoid mismatches between content and file extension, this setting needs to be manually updated to reflect the terminus changes\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$statedir/last_run_report\.yaml\fR
@@ -1053,7 +1053,7 @@ The LDAP attributes to include when querying LDAP for nodes\. All returned attri
 The search base for LDAP searches\. It\'s impossible to provide a meaningful default here, although the LDAP libraries might have one already set\. Generally, it should be the \'ou=Hosts\' branch under your main directory\.
 .
 .SS "ldapclassattrs"
-The LDAP attributes to use to define Puppet classes\. Values should be comma\-separated\.
+The LDAP attributes to use to define classes\. Values should be comma\-separated\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppetclass\fR
@@ -1123,7 +1123,7 @@ Whether TLS should be used when searching for nodes\. Defaults to false because 
 The user to use to connect to LDAP\. Must be specified as a full DN\.
 .
 .SS "libdir"
-An extra search path for Puppet\. This is only useful for those files that Puppet will load on demand, and is only guaranteed to work for those cases\. In fact, the autoload mechanism is responsible for making sure this directory is in Ruby\'s search path
+An extra search path for OpenVox\. This is only useful for those files that OpenVox will load on demand, and is only guaranteed to work for those cases\. In fact, the autoload mechanism is responsible for making sure this directory is in Ruby\'s search path
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$vardir/lib\fR
@@ -1139,7 +1139,7 @@ Where each client stores the CA certificate\.
 .IP "" 0
 .
 .SS "localedest"
-Where Puppet should store translation files that it pulls down from the central server\.
+Where OpenVox should store translation files that it pulls down from the central server\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$vardir/locales\fR
@@ -1147,7 +1147,7 @@ Where Puppet should store translation files that it pulls down from the central 
 .IP "" 0
 .
 .SS "localesource"
-From where to retrieve translation files\. The standard Puppet \fBfile\fR type is used for retrieval, so anything that is a valid file source can be used here\.
+From where to retrieve translation files\. The standard OpenVox \fBfile\fR type is used for retrieval, so anything that is a valid file source can be used here\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet:///locales\fR
@@ -1155,7 +1155,7 @@ From where to retrieve translation files\. The standard Puppet \fBfile\fR type i
 .IP "" 0
 .
 .SS "location_trusted"
-This will allow sending the name + password and the cookie header to all hosts that puppet may redirect to\. This may or may not introduce a security breach if puppet redirects you to a site to which you\'ll send your authentication info and cookies\.
+This will allow sending the name + password and the cookie header to all hosts that OpenVox may redirect to\. This may or may not introduce a security breach if OpenVox redirects you to a site to which you\'ll send your authentication info and cookies\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1163,7 +1163,7 @@ This will allow sending the name + password and the cookie header to all hosts t
 .IP "" 0
 .
 .SS "log_level"
-Default logging level for messages from Puppet\. Allowed values are:
+Default logging level for messages from OpenVox\. Allowed values are:
 .
 .IP "\(bu" 4
 debug
@@ -1211,7 +1211,7 @@ The directory in which to store log files
 .IP "" 0
 .
 .SS "manage_internal_file_permissions"
-Whether Puppet should manage the owner, group, and mode of files it uses internally\. \fBNote\fR: For Windows agents, the default is \fBfalse\fR for versions 4\.10\.13 and greater, versions 5\.5\.6 and greater, and versions 6\.0 and greater\.
+Whether OpenVox should manage the owner, group, and mode of files it uses internally\. \fBNote\fR: For Windows agents, the default is \fBfalse\fR for versions 4\.10\.13 and greater, versions 5\.5\.6 and greater, and versions 6\.0 and greater\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBtrue\fR
@@ -1219,7 +1219,7 @@ Whether Puppet should manage the owner, group, and mode of files it uses interna
 .IP "" 0
 .
 .SS "manifest"
-The entry\-point manifest for the primary server\. This can be one file or a directory of manifests to be evaluated in alphabetical order\. Puppet manages this path as a directory if one exists or if the path ends with a / or \.
+The entry\-point manifest for the primary server\. This can be one file or a directory of manifests to be evaluated in alphabetical order\. OpenVox manages this path as a directory if one exists or if the path ends with a / or \.
 .
 .P
 Setting a global value for \fBmanifest\fR in puppet\.conf is not allowed (but it can be overridden from the commandline)\. Please use directory environments instead\. If you need to use something other than the environment\'s \fBmanifests\fR directory as the main manifest, you can set \fBmanifest\fR in environment\.conf\. For more info, see \fIhttps://puppet\.com/docs/puppet/latest/environments_about\.html\fR
@@ -1230,7 +1230,7 @@ Setting a global value for \fBmanifest\fR in puppet\.conf is not allowed (but it
 .IP "" 0
 .
 .SS "masterport"
-The default port puppet subcommands use to communicate with Puppet Server\. (eg \fBpuppet facts upload\fR, \fBpuppet agent\fR)\. May be overridden by more specific settings (see \fBca_port\fR, \fBreport_port\fR)\.
+The default port puppet subcommands use to communicate with the server\. (eg \fBpuppet facts upload\fR, \fBpuppet agent\fR)\. May be overridden by more specific settings (see \fBca_port\fR, \fBreport_port\fR)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB8140\fR
@@ -1270,7 +1270,7 @@ The maximum allowed UID\. Some platforms use negative UIDs but then ship with to
 .IP "" 0
 .
 .SS "maxwaitforcert"
-The maximum amount of time the Puppet agent should wait for its certificate request to be signed\. A value of \fBunlimited\fR will cause puppet agent to ask for a signed certificate indefinitely\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+The maximum amount of time the agent should wait for its certificate request to be signed\. A value of \fBunlimited\fR will cause the agent to ask for a signed certificate indefinitely\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBunlimited\fR
@@ -1278,7 +1278,7 @@ The maximum amount of time the Puppet agent should wait for its certificate requ
 .IP "" 0
 .
 .SS "maxwaitforlock"
-The maximum amount of time the puppet agent should wait for an already running puppet agent to finish before starting a new one\. This is set by default to 1 minute\. A value of \fBunlimited\fR will cause puppet agent to wait indefinitely\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+The maximum amount of time the agent should wait for an already running agent to finish before starting a new one\. This is set by default to 1 minute\. A value of \fBunlimited\fR will cause the agent to wait indefinitely\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB1m\fR
@@ -1300,7 +1300,7 @@ If true, all messages caused by a class dependency failure are merged into one m
 .IP "" 0
 .
 .SS "mkusers"
-Whether to create the necessary user and group that puppet agent will run as\.
+Whether to create the necessary user and group that the agent will run as\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1308,7 +1308,7 @@ Whether to create the necessary user and group that puppet agent will run as\.
 .IP "" 0
 .
 .SS "module_groups"
-Extra module groups to request from the Puppet Forge\. This is an internal setting, and users should never change it\.
+Extra module groups to request from The Forge\. This is an internal setting, and users should never change it\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: ``
@@ -1370,10 +1370,10 @@ How to store cached nodes\. Valid values are (none), \'json\', \'msgpack\', or \
 .IP "" 0
 .
 .SS "node_name_fact"
-The fact name used to determine the node name used for all requests the agent makes to the primary server\. WARNING: This setting is mutually exclusive with node_name_value\. Changing this setting also requires changes to Puppet Server\'s default auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\.
+The fact name used to determine the node name used for all requests the agent makes to the primary server\. WARNING: This setting is mutually exclusive with node_name_value\. Changing this setting also requires changes to the server\'s default auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\.
 .
 .SS "node_name_value"
-The explicit value used for the node name for all requests the agent makes to the primary server\. WARNING: This setting is mutually exclusive with node_name_fact\. Changing this setting also requires changes to Puppet Server\'s default auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\.
+The explicit value used for the node name for all requests the agent makes to the primary server\. WARNING: This setting is mutually exclusive with node_name_fact\. Changing this setting also requires changes to OpenVox Server\'s default auth\.conf \fIhttps://puppet\.com/docs/puppetserver/latest/config_file_auth\.html\fR\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$certname\fR
@@ -1384,13 +1384,13 @@ The explicit value used for the node name for all requests the agent makes to th
 Which node data plugin to use when compiling node catalogs\.
 .
 .P
-When Puppet compiles a catalog, it combines two primary sources of info: the main manifest, and a node data plugin (often called a "node terminus," for historical reasons)\. Node data plugins provide three things for a given node name:
+When OpenVox compiles a catalog, it combines two primary sources of info: the main manifest, and a node data plugin (often called a "node terminus," for historical reasons)\. Node data plugins provide three things for a given node name:
 .
 .IP "1." 4
 A list of classes to add to that node\'s catalog (and, optionally, values for their parameters)\.
 .
 .IP "2." 4
-Which Puppet environment the node should use\.
+Which OpenVox environment the node should use\.
 .
 .IP "3." 4
 A list of additional top\-scope variables to set\.
@@ -1404,7 +1404,7 @@ The three main node data plugins are:
 \fBplain\fR \-\-\- Returns no data, so that the main manifest controls all node configuration\.
 .
 .IP "\(bu" 4
-\fBexec\fR \-\-\- Uses an external node classifier (ENC) \fIhttps://puppet\.com/docs/puppet/latest/nodes_external\.html\fR, configured by the \fBexternal_nodes\fR setting\. This lets you pull a list of Puppet classes from any external system, using a small glue script to perform the request and format the result as YAML\.
+\fBexec\fR \-\-\- Uses an external node classifier (ENC) \fIhttps://puppet\.com/docs/puppet/latest/nodes_external\.html\fR, configured by the \fBexternal_nodes\fR setting\. This lets you pull a list of classes from any external system, using a small glue script to perform the request and format the result as YAML\.
 .
 .IP "\(bu" 4
 \fBclassifier\fR (formerly \fBconsole\fR) \-\-\- Specific to Puppet Enterprise\. Uses the PE console for node data\."
@@ -1415,13 +1415,13 @@ The three main node data plugins are:
 .IP "" 0
 .
 .SS "noop"
-Whether to apply catalogs in noop mode, which allows Puppet to partially simulate a normal run\. This setting affects puppet agent and puppet apply\.
+Whether to apply catalogs in noop mode, which allows OpenVox to partially simulate a normal run\. This setting affects puppet agent and puppet apply\.
 .
 .P
-When running in noop mode, Puppet will check whether each resource is in sync, like it does when running normally\. However, if a resource attribute is not in the desired state (as declared in the catalog), Puppet will take no action, and will instead report the changes it \fIwould\fR have made\. These simulated changes will appear in the report sent to the primary Puppet server, or be shown on the console if running puppet agent or puppet apply in the foreground\. The simulated changes will not send refresh events to any subscribing or notified resources, although Puppet will log that a refresh event \fIwould\fR have been sent\.
+When running in noop mode, OpenVox will check whether each resource is in sync, like it does when running normally\. However, if a resource attribute is not in the desired state (as declared in the catalog), OpenVox will take no action, and will instead report the changes it \fIwould\fR have made\. These simulated changes will appear in the report sent to the primary OpenVox server, or be shown on the console if running puppet agent or puppet apply in the foreground\. The simulated changes will not send refresh events to any subscribing or notified resources, although OpenVox will log that a refresh event \fIwould\fR have been sent\.
 .
 .P
-\fBImportant note:\fR The \fBnoop\fR metaparameter \fIhttps://puppet\.com/docs/puppet/latest/metaparameter\.html#noop\fR allows you to apply individual resources in noop mode, and will override the global value of the \fBnoop\fR setting\. This means a resource with \fBnoop => false\fR \fIwill\fR be changed if necessary, even when running puppet agent with \fBnoop = true\fR or \fB\-\-noop\fR\. (Conversely, a resource with \fBnoop => true\fR will only be simulated, even when noop mode is globally disabled\.)
+\fBImportant note:\fR The \fBnoop\fR metaparameter \fIhttps://puppet\.com/docs/puppet/latest/metaparameter\.html#noop\fR allows you to apply individual resources in noop mode, and will override the global value of the \fBnoop\fR setting\. This means a resource with \fBnoop => false\fR \fIwill\fR be changed if necessary, even when running the agent with \fBnoop = true\fR or \fB\-\-noop\fR\. (Conversely, a resource with \fBnoop => true\fR will only be simulated, even when noop mode is globally disabled\.)
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1437,7 +1437,7 @@ The soft limit for the total number of fact values\. This counts the child eleme
 .IP "" 0
 .
 .SS "onetime"
-Perform one configuration run and exit, rather than spawning a long\-running daemon\. This is useful for interactively running puppet agent, or running puppet agent from cron\.
+Perform one configuration run and exit, rather than spawning a long\-running daemon\. This is useful for interactively running the agent, or running the agent from cron\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1445,7 +1445,7 @@ Perform one configuration run and exit, rather than spawning a long\-running dae
 .IP "" 0
 .
 .SS "passfile"
-Where puppet agent stores the password for its private key\. Generally unused\.
+Where the agent stores the password for its private key\. Generally unused\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$privatedir/password\fR
@@ -1480,7 +1480,7 @@ The file containing the PID of a running process\. This file is intended to be u
 .IP "" 0
 .
 .SS "plugindest"
-Where Puppet should store plugins that it pulls down from the central server\.
+Where OpenVox should store plugins that it pulls down from the central server\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$libdir\fR
@@ -1488,7 +1488,7 @@ Where Puppet should store plugins that it pulls down from the central server\.
 .IP "" 0
 .
 .SS "pluginfactdest"
-Where Puppet should store external facts that are being handled by pluginsync
+Where OpenVox should store external facts that are being handled by pluginsync
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$vardir/facts\.d\fR
@@ -1512,7 +1512,7 @@ What files to ignore when pulling down plugins\.
 .IP "" 0
 .
 .SS "pluginsource"
-From where to retrieve plugins\. The standard Puppet \fBfile\fR type is used for retrieval, so anything that is a valid file source can be used here\.
+From where to retrieve plugins\. The standard OpenVox \fBfile\fR type is used for retrieval, so anything that is a valid file source can be used here\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet:///plugins\fR
@@ -1528,7 +1528,7 @@ Whether plugins should be synced with the central server\. This setting is depre
 .IP "" 0
 .
 .SS "postrun_command"
-A command to run after every agent run\. If this command returns a non\-zero return code, the entire Puppet run will be considered to have failed, even though it might have performed work during the normal run\.
+A command to run after every agent run\. If this command returns a non\-zero return code, the entire run will be considered to have failed, even though it might have performed work during the normal run\.
 .
 .SS "preferred_serialization_format"
 The preferred means of serializing ruby instances for passing over the wire\. This won\'t guarantee that all instances will be serialized using this method, since not all classes can be guaranteed to support this format, but it will be used for all classes that support it\.
@@ -1539,7 +1539,7 @@ The preferred means of serializing ruby instances for passing over the wire\. Th
 .IP "" 0
 .
 .SS "preprocess_deferred"
-Whether Puppet should call deferred functions before applying the catalog\. If set to \fBtrue\fR, all prerequisites required for the deferred function must be satisfied before the Puppet run\. If set to \fBfalse\fR, deferred functions follow Puppet relationships and ordering\. In this way, Puppet can install the prerequisites required for a deferred function and call the deferred function in the same run\.
+Whether OpenVox should call deferred functions before applying the catalog\. If set to \fBtrue\fR, all prerequisites required for the deferred function must be satisfied before the run\. If set to \fBfalse\fR, deferred functions follow OpenVox relationships and ordering\. In this way, OpenVox can install the prerequisites required for a deferred function and call the deferred function in the same run\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1558,7 +1558,7 @@ The directory where catalog previews per node are generated\.
 .IP "" 0
 .
 .SS "priority"
-The scheduling priority of the process\. Valid values are \'high\', \'normal\', \'low\', or \'idle\', which are mapped to platform\-specific values\. The priority can also be specified as an integer value and will be passed as is, e\.g\. \-5\. Puppet must be running as a privileged user in order to increase scheduling priority\.
+The scheduling priority of the process\. Valid values are \'high\', \'normal\', \'low\', or \'idle\', which are mapped to platform\-specific values\. The priority can also be specified as an integer value and will be passed as is, e\.g\. \-5\. OpenVox must be running as a privileged user in order to increase scheduling priority\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: ``
@@ -1590,7 +1590,7 @@ Whether to enable experimental performance profiling
 .IP "" 0
 .
 .SS "publicdir"
-Where Puppet stores public files\.
+Where OpenVox stores public files\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBUnix/Linux: /opt/puppetlabs/puppet/public \-\- Windows: C:\eProgramData\ePuppetLabs\epuppet\epublic \-\- Non\-root user: ~/\.puppetlabs/opt/puppet/public\fR
@@ -1614,10 +1614,10 @@ Whether to print the Puppet stack trace on some errors\. This is a noop if \fBtr
 .IP "" 0
 .
 .SS "puppetdlog"
-The fallback log file\. This is only used when the \fB\-\-logdest\fR option is not specified AND Puppet is running on an operating system where both the POSIX syslog service and the Windows Event Log are unavailable\. (Currently, no supported operating systems match that description\.)
+The fallback log file\. This is only used when the \fB\-\-logdest\fR option is not specified AND OpenVox is running on an operating system where both the POSIX syslog service and the Windows Event Log are unavailable\. (Currently, no supported operating systems match that description\.)
 .
 .P
-Despite the name, both puppet agent and puppet server will use this file as the fallback logging destination\.
+Despite the name, both OpenVox agent and OpenVox server will use this file as the fallback logging destination\.
 .
 .P
 For control over logging destinations, see the \fB\-\-logdest\fR command line option in the manual pages for puppet server, puppet agent, and puppet apply\. You can see man pages by running \fBpuppet <SUBCOMMAND> \-\-help\fR, or read them online at https://puppet\.com/docs/puppet/latest/man/\.
@@ -1636,7 +1636,7 @@ Whether to send reports after every transaction\.
 .IP "" 0
 .
 .SS "report_configured_environmentpath"
-Specifies how environment paths are reported\. When the value of \fBversioned_environment_dirs\fR is \fBtrue\fR, Puppet applies the readlink function to the \fBenvironmentpath\fR setting when constructing the environment\'s modulepath\. The full readlinked path is referred to as the "resolved path," and the configured path potentially containing symlinks is the "configured path\." When reporting where resources come from, users may choose between the configured and resolved path\.
+Specifies how environment paths are reported\. When the value of \fBversioned_environment_dirs\fR is \fBtrue\fR, OpenVox applies the readlink function to the \fBenvironmentpath\fR setting when constructing the environment\'s modulepath\. The full readlinked path is referred to as the "resolved path," and the configured path potentially containing symlinks is the "configured path\." When reporting where resources come from, users may choose between the configured and resolved path\.
 .
 .P
 When set to \fBfalse\fR, the resolved paths are reported instead of the configured paths\.
@@ -1682,7 +1682,7 @@ The directory in which to store reports\. Each node gets a separate subdirectory
 The list of report handlers to use\. When using multiple report handlers, their names should be comma\-separated, with whitespace allowed\. (For example, \fBreports = http, store\fR\.)
 .
 .P
-This setting is relevant to puppet server and puppet apply\. The primary Puppet server will call these report handlers with the reports it receives from agent nodes, and puppet apply will call them with its own report\. (In all cases, the node applying the catalog must have \fBreport = true\fR\.)
+This setting is relevant to the server and the puppet apply command\. The primary server will call these report handlers with the reports it receives from agent nodes, and puppet apply will call them with its own report\. (In all cases, the node applying the catalog must have \fBreport = true\fR\.)
 .
 .P
 See the report reference for information on the built\-in report handlers; custom report handlers can also be loaded from modules\. (Report handlers are loaded from the lib directory, at \fBpuppet/reports/NAME\.rb\fR\.)
@@ -1712,7 +1712,7 @@ Where host certificate requests are stored\.
 .IP "" 0
 .
 .SS "resourcefile"
-The file in which puppet agent stores a list of the resources associated with the retrieved configuration\.
+The file in which the agent stores a list of the resources associated with the retrieved configuration\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$statedir/resources\.txt\fR
@@ -1720,7 +1720,7 @@ The file in which puppet agent stores a list of the resources associated with th
 .IP "" 0
 .
 .SS "resubmit_facts"
-Whether to send updated facts after every transaction\. By default puppet only submits facts at the beginning of the transaction before applying a catalog\. Since puppet can modify the state of the system, the value of the facts may change after puppet finishes\. Therefore, any facts stored in puppetdb may not be consistent until the agent next runs, typically in 30 minutes\. If this feature is enabled, puppet will resubmit facts after applying its catalog, ensuring facts for the node stored in puppetdb are current\. However, this will double the fact submission load on puppetdb, so it is disabled by default\.
+Whether to send updated facts after every transaction\. By default, OpenVox only submits facts at the beginning of the transaction before applying a catalog\. Since OpenVox can modify the state of the system, the value of the facts may change after OpenVox finishes\. Therefore, any facts stored in The OpenVox Database may not be consistent until the agent next runs, typically in 30 minutes\. If this feature is enabled, OpenVox will resubmit facts after applying its catalog, ensuring facts for the node stored in the database are current\. However, this will double the fact submission load on the database, so it is disabled by default\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1744,7 +1744,7 @@ The YAML file containing indirector route configuration\.
 .IP "" 0
 .
 .SS "rundir"
-Where Puppet PID files are kept\.
+Where OpenVox PID files are kept\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBUnix/Linux: /var/run/puppetlabs \-\- Windows: C:\eProgramData\ePuppetLabs\epuppet\evar\erun \-\- Non\-root user: ~/\.puppetlabs/var/run\fR
@@ -1752,7 +1752,7 @@ Where Puppet PID files are kept\.
 .IP "" 0
 .
 .SS "runinterval"
-How often puppet agent applies the catalog\. Note that a runinterval of 0 means "run continuously" rather than "never run\." This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+How often the agent applies the catalog\. Note that a runinterval of 0 means "run continuously" rather than "never run\." This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB30m\fR
@@ -1760,7 +1760,7 @@ How often puppet agent applies the catalog\. Note that a runinterval of 0 means 
 .IP "" 0
 .
 .SS "runtimeout"
-The maximum amount of time an agent run is allowed to take\. A Puppet agent run that exceeds this timeout will be aborted\. A value of 0 disables the timeout\. Defaults to 1 hour\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+The maximum amount of time an agent run is allowed to take\. An agent run that exceeds this timeout will be aborted\. A value of 0 disables the timeout\. Defaults to 1 hour\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB1h\fR
@@ -1776,7 +1776,7 @@ Where the serial number for certificates is stored\.
 .IP "" 0
 .
 .SS "server"
-The primary Puppet server to which the Puppet agent should connect\.
+The primary OpenVox server to which the agent should connect\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet\fR
@@ -1792,7 +1792,7 @@ The directory in which serialized data is stored, usually in a subdirectory\.
 .IP "" 0
 .
 .SS "server_list"
-The list of primary Puppet servers to which the Puppet agent should connect, in the order that they will be tried\. Each value should be a fully qualified domain name, followed by an optional \':\' and port number\. If a port is omitted, Puppet uses masterport for that host\.
+The list of primary OpenVox servers to which the agent should connect, in the order that they will be tried\. Each value should be a fully qualified domain name, followed by an optional \':\' and port number\. If a port is omitted, OpenVox uses masterport for that host\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB[]\fR
@@ -1800,7 +1800,7 @@ The list of primary Puppet servers to which the Puppet agent should connect, in 
 .IP "" 0
 .
 .SS "serverport"
-The default port puppet subcommands use to communicate with Puppet Server\. (eg \fBpuppet facts upload\fR, \fBpuppet agent\fR)\. May be overridden by more specific settings (see \fBca_port\fR, \fBreport_port\fR)\.
+The default port OpenVox subcommands use to communicate with the server\. (eg \fBpuppet facts upload\fR, \fBpuppet agent\fR)\. May be overridden by more specific settings (see \fBca_port\fR, \fBreport_port\fR)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB8140\fR
@@ -1816,7 +1816,7 @@ Whether to compile and apply the settings catalog
 .IP "" 0
 .
 .SS "show_diff"
-Whether to log and report a contextual diff when files are being replaced\. This causes partial file contents to pass through Puppet\'s normal logging and reporting system, so this setting should be used with caution if you are sending Puppet\'s reports to an insecure destination\. This feature currently requires the \fBdiff/lcs\fR Ruby library\.
+Whether to log and report a contextual diff when files are being replaced\. This causes partial file contents to pass through OpenVox\'s normal logging and reporting system, so this setting should be used with caution if you are sending OpenVox\'s reports to an insecure destination\. This feature currently requires the \fBdiff/lcs\fR Ruby library\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1860,7 +1860,7 @@ For example, assume a default 30\-minute \fB$runinterval\fR, \fBsplay\fR set to 
 With \fBsplay\fR enabled, it waits any amount of time up to its \fB$splaylimit\fR before its first run\. For example, it might randomly wait 8 minutes, then start its first run at :08 past the hour\. With the \fB$runinterval\fR at its default 30 minutes, its next run will be at :38 past the hour\.
 .
 .P
-If you restart an agent\'s puppet service with \fBsplay\fR enabled, it recalculates its splay period and delays its first agent run after restarting for this new period\. If you simultaneously restart a group of puppet agents with \fBsplay\fR enabled, their checkins to your primary servers can be distributed more evenly\.
+If you restart an agent\'s service with \fBsplay\fR enabled, it recalculates its splay period and delays its first agent run after restarting for this new period\. If you simultaneously restart a group of agents with \fBsplay\fR enabled, their checkins to your primary servers can be distributed more evenly\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -1884,7 +1884,7 @@ The domain which will be queried to find the SRV records of servers to use\.
 .IP "" 0
 .
 .SS "ssl_client_header"
-The header containing an authenticated client\'s SSL DN\. This header must be set by the proxy to the authenticated client\'s SSL DN (e\.g\., \fB/CN=puppet\.puppetlabs\.com\fR)\. Puppet will parse out the Common Name (CN) from the Distinguished Name (DN) and use the value of the CN field for authorization\.
+The header containing an authenticated client\'s SSL DN\. This header must be set by the proxy to the authenticated client\'s SSL DN (e\.g\., \fB/CN=puppet\.puppetlabs\.com\fR)\. OpenVox will parse out the Common Name (CN) from the Distinguished Name (DN) and use the value of the CN field for authorization\.
 .
 .P
 Note that the name of the HTTP header gets munged by the web server common gateway interface: an \fBHTTP_\fR prefix is added, dashes are converted to underscores, and all letters are uppercased\. Thus, to use the \fBX\-Client\-DN\fR header, this setting should be \fBHTTP_X_CLIENT_DN\fR\.
@@ -1914,7 +1914,7 @@ A lock file to indicate that the ssl bootstrap process is currently in progress\
 .IP "" 0
 .
 .SS "ssl_trust_store"
-A file containing CA certificates in PEM format that puppet should trust when making HTTPS requests\. This \fBonly\fR applies to https requests to non\-puppet infrastructure, such as retrieving file metadata and content from https file sources, puppet module tool and the \'http\' report processor\. This setting is ignored when making requests to puppet:// URLs such as catalog and report requests\.
+A file containing CA certificates in PEM format that puppet should trust when making HTTPS requests\. This \fBonly\fR applies to https requests to non\-OpenVox infrastructure, such as retrieving file metadata and content from https file sources, OpenVox module tool and the \'http\' report processor\. This setting is ignored when making requests to puppet:// URLs such as catalog and report requests\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: ``
@@ -1930,7 +1930,7 @@ Where SSL certificates are kept\.
 .IP "" 0
 .
 .SS "statedir"
-The directory where Puppet state is stored\. Generally, this directory can be removed without causing harm (although it might result in spurious service restarts)\.
+The directory where OpenVox state is stored\. Generally, this directory can be removed without causing harm (although it might result in spurious service restarts)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$vardir/state\fR
@@ -1938,7 +1938,7 @@ The directory where Puppet state is stored\. Generally, this directory can be re
 .IP "" 0
 .
 .SS "statefile"
-Where Puppet agent and Puppet Server store state associated with the running configuration\. In the case of Puppet Server, this file reflects the state discovered through interacting with clients\.
+Where OpenVox agent and server store state associated with the running configuration\. In the case of OpenVox Server, this file reflects the state discovered through interacting with clients\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB$statedir/state\.yaml\fR
@@ -1946,7 +1946,7 @@ Where Puppet agent and Puppet Server store state associated with the running con
 .IP "" 0
 .
 .SS "statettl"
-How long the Puppet agent should cache when a resource was last checked or synced\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\. A value of \fB0\fR or \fBunlimited\fR will disable cache pruning\.
+How long the agent should cache when a resource was last checked or synced\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\. A value of \fB0\fR or \fBunlimited\fR will disable cache pruning\.
 .
 .P
 This setting affects the usage of \fBschedule\fR resources, as the information about when a resource was last checked (and therefore when it needs to be checked again) is stored in the \fBstatefile\fR\. The \fBstatettl\fR needs to be large enough to ensure that a resource will not trigger multiple times during a schedule due to its entry expiring from the cache\.
@@ -1957,7 +1957,7 @@ This setting affects the usage of \fBschedule\fR resources, as the information a
 .IP "" 0
 .
 .SS "static_catalogs"
-Whether to compile a static catalog \fIhttps://puppet\.com/docs/puppet/latest/static_catalogs\.html#enabling\-or\-disabling\-static\-catalogs\fR, which occurs only on Puppet Server when the \fBcode\-id\-command\fR and \fBcode\-content\-command\fR settings are configured in its \fBpuppetserver\.conf\fR file\.
+Whether to compile a static catalog \fIhttps://puppet\.com/docs/puppet/latest/static_catalogs\.html#enabling\-or\-disabling\-static\-catalogs\fR, which occurs only on OpenVox Server when the \fBcode\-id\-command\fR and \fBcode\-content\-command\fR settings are configured in its \fBpuppetserver\.conf\fR file\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBtrue\fR
@@ -1979,7 +1979,7 @@ You can adjust the backend using the storeconfigs_backend setting\.
 .IP "" 0
 .
 .SS "storeconfigs_backend"
-Configure the backend terminus used for StoreConfigs\. By default, this uses the PuppetDB store, which must be installed and configured before turning on StoreConfigs\.
+Configure the backend terminus used for StoreConfigs\. By default, this uses the OpenVoxDB store, which must be installed and configured before turning on StoreConfigs\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppetdb\fR
@@ -1987,7 +1987,7 @@ Configure the backend terminus used for StoreConfigs\. By default, this uses the
 .IP "" 0
 .
 .SS "strict"
-The strictness level of puppet\. Allowed values are:
+The strictness level of OpenVox\. Allowed values are:
 .
 .IP "\(bu" 4
 off \- do not perform extra validation, do not report
@@ -2117,7 +2117,7 @@ File that provides mapping between custom SSL oids and user\-friendly names
 .IP "" 0
 .
 .SS "use_cached_catalog"
-Whether to only use the cached catalog rather than compiling a new catalog on every run\. Puppet can be run with this enabled by default and then selectively disabled when a recompile is desired\. Because a Puppet agent using cached catalogs does not contact the primary server for a new catalog, it also does not upload facts at the beginning of the Puppet run\.
+Whether to only use the cached catalog rather than compiling a new catalog on every run\. OpenVox can be run with this enabled by default and then selectively disabled when a recompile is desired\. Because an agent using cached catalogs does not contact the primary server for a new catalog, it also does not upload facts at the beginning of the run\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR
@@ -2125,7 +2125,7 @@ Whether to only use the cached catalog rather than compiling a new catalog on ev
 .IP "" 0
 .
 .SS "use_last_environment"
-Puppet saves both the initial and converged environment in the last_run_summary file\. If they differ, and this setting is set to true, we will use the last converged environment and skip the node request\.
+OpenVox saves both the initial and converged environment in the last_run_summary file\. If they differ, and this setting is set to true, we will use the last converged environment and skip the node request\.
 .
 .P
 When set to false, we will do the node request and ignore the environment data from the last_run_summary file\.
@@ -2152,7 +2152,7 @@ Whether to use the cached configuration when the remote configuration will not c
 .IP "" 0
 .
 .SS "user"
-The user Puppet Server will run as\. Used to ensure the agent side processes (agent, apply, etc) create files and directories readable by Puppet Server when necessary\.
+The user OpenVox Server will run as\. Used to ensure the agent side processes (agent, apply, etc) create files and directories readable by Puppet Server when necessary\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBpuppet\fR
@@ -2160,7 +2160,7 @@ The user Puppet Server will run as\. Used to ensure the agent side processes (ag
 .IP "" 0
 .
 .SS "vardir"
-Where Puppet stores dynamic and growing data\. The default for this setting is calculated specially, like \fBconfdir\fR_\.
+Where OpenVox stores dynamic and growing data\. The default for this setting is calculated specially, like \fBconfdir\fR_\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBUnix/Linux: /opt/puppetlabs/puppet/cache \-\- Windows: C:\eProgramData\ePuppetLabs\epuppet\ecache \-\- Non\-root user: ~/\.puppetlabs/opt/puppet/cache\fR
@@ -2184,13 +2184,13 @@ Whether or not to look for versioned environment directories, symlinked from \fB
 .IP "" 0
 .
 .SS "waitforcert"
-How frequently puppet agent should ask for a signed certificate\.
+How frequently the agent should ask for a signed certificate\.
 .
 .P
-When starting for the first time, puppet agent will submit a certificate signing request (CSR) to the server named in the \fBca_server\fR setting (usually the primary Puppet server); this may be autosigned, or may need to be approved by a human, depending on the CA server\'s configuration\.
+When starting for the first time, the agent will submit a certificate signing request (CSR) to the server named in the \fBca_server\fR setting (usually the primary Puppet server); this may be autosigned, or may need to be approved by a human, depending on the CA server\'s configuration\.
 .
 .P
-Puppet agent cannot apply configurations until its approved certificate is available\. Since the certificate may or may not be available immediately, puppet agent will repeatedly try to fetch it at this interval\. You can turn off waiting for certificates by specifying a time of 0, or a maximum amount of time to wait in the \fBmaxwaitforcert\fR setting, in which case puppet agent will exit if it cannot get a cert\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+The agent cannot apply configurations until its approved certificate is available\. Since the certificate may or may not be available immediately, the agent will repeatedly try to fetch it at this interval\. You can turn off waiting for certificates by specifying a time of 0, or a maximum amount of time to wait in the \fBmaxwaitforcert\fR setting, in which case the agent will exit if it cannot get a cert\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB2m\fR
@@ -2198,10 +2198,10 @@ Puppet agent cannot apply configurations until its approved certificate is avail
 .IP "" 0
 .
 .SS "waitforlock"
-How frequently puppet agent should try running when there is an already ongoing puppet agent instance\.
+How frequently the agent should try running when there is an already ongoing puppet agent instance\.
 .
 .P
-This argument is by default disabled (value set to 0)\. In this case puppet agent will immediately exit if it cannot run at that moment\. When a value other than 0 is set, this can also be used in combination with the \fBmaxwaitforlock\fR argument\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
+This argument is by default disabled (value set to 0)\. In this case the agent will immediately exit if it cannot run at that moment\. When a value other than 0 is set, this can also be used in combination with the \fBmaxwaitforlock\fR argument\. This setting can be a time interval in seconds (30 or 30s), minutes (30m), hours (6h), days (2d), or years (5y)\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fB0\fR

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,24 +1,24 @@
 Gem::Specification.new do |spec|
-  spec.name = "puppet"
+  spec.name = "openvox"
   spec.version = "8.11.0"
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
   spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
-  spec.authors = ["Puppet Labs"]
+  spec.authors = ["Vox Pupuli"]
   spec.date = "2012-08-17"
   spec.description = <<~EOF
-    Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+    OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
     (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
   EOF
-  spec.email = "info@puppetlabs.com"
+  spec.email = "pmc@voxpupuli.org."
   spec.executables = ["puppet"]
   spec.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
   spec.license = "Apache-2.0"
-  spec.homepage = "https://github.com/puppetlabs/puppet"
-  spec.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
+  spec.homepage = "https://github.com/OpenVoxProject/puppet"
+  spec.rdoc_options = ["--title", "OpenVox - Configuration Management", "--main", "README", "--line-numbers"]
   spec.require_paths = ["lib"]
-  spec.summary = "Puppet, an automated configuration management tool"
+  spec.summary = "OpenVox, a community implementation of Puppet -- an automated configuration management tool"
   spec.specification_version = 4
   spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
   spec.add_runtime_dependency('deep_merge', '~> 1.0')

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
     OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
     (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
   EOF
-  spec.email = "pmc@voxpupuli.org."
+  spec.email = "openvox@voxpupuli.org."
   spec.executables = ["puppet"]
   spec.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
   spec.license = "Apache-2.0"

--- a/rakelib/generate_references.rake
+++ b/rakelib/generate_references.rake
@@ -287,7 +287,7 @@ namespace :references do
     variables = {
       sha: sha,
       now: now,
-      title: 'Puppet Man Pages',
+      title: 'OpenVox Man Pages',
       core_apps: core_apps,
       occasional_apps: occasional_apps,
       weird_apps: weird_apps

--- a/rakelib/man/puppet.erb
+++ b/rakelib/man/puppet.erb
@@ -1,4 +1,4 @@
-puppet(8) - an automated configuration management tool
+puppet(8) - OpenVox is an automated configuration management tool
 =========
 
 ## SYNOPSIS
@@ -7,7 +7,7 @@ puppet(8) - an automated configuration management tool
 
 ## DESCRIPTION
 
-Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems that performs administrative tasks
 (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
 
 ## COMMANDS

--- a/rakelib/man/puppet.erb
+++ b/rakelib/man/puppet.erb
@@ -7,7 +7,7 @@ puppet(8) - OpenVox is an automated configuration management tool
 
 ## DESCRIPTION
 
-OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems that performs administrative tasks
+OpenVox is a community implementation of Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, designed to perform administrative tasks
 (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
 
 ## COMMANDS

--- a/rakelib/manpages.rake
+++ b/rakelib/manpages.rake
@@ -1,4 +1,4 @@
-desc "Build Puppet manpages"
+desc "Build OpenVox manpages"
 task :gen_manpages do
   require 'puppet/face'
   require 'fileutils'
@@ -12,7 +12,7 @@ task :gen_manpages do
   faces.delete('strings')
   apps = non_face_applications + faces
 
-  ronn_args = '--manual="Puppet manual" --organization="Puppet, Inc." --roff'
+  ronn_args = '--manual="OpenVox manual" --organization="Vox Pupuli" --roff'
 
   unless ENV['SOURCE_DATE_EPOCH'].nil?
     source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d')

--- a/rakelib/references/man.erb
+++ b/rakelib/references/man.erb
@@ -7,6 +7,6 @@ canonical: "<%= canonical %>"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 <%= body %>

--- a/rakelib/references/man/overview.erb
+++ b/rakelib/references/man/overview.erb
@@ -7,16 +7,16 @@ canonical: "/puppet/latest/man/overview.html"
 
 # <%= title %>
 
-> **NOTE:** This page was generated from the Puppet source code on <%= now %>
+> **NOTE:** This page was generated from the OpenVox source code on <%= now %>
 
 
 
-Puppet's command line tools consist of a single `puppet` binary with many subcommands. The following subcommands are available in this version of Puppet:
+OpenVox's command line tools consist of a single `puppet` binary with many subcommands. The following subcommands are available in this version of OpenVox:
 
 Core Tools
 -----
 
-These subcommands form the core of Puppet's tool set, and every user should understand what they do.
+These subcommands form the core of OpenVox's tool set, and every user should understand what they do.
 
 <% core_apps.each do |app| -%>
 - [puppet <%= app %>](<%= app %>.md)


### PR DESCRIPTION
This should update to OpenVox in help output and man pages. It also adds
a debranded README and gemspec. Supercedes #2, removing generated man
pages by request. We'll generate them after we're done making changes.

If you'd like to help, feel free to check out this branch/PR and push
your own commits back to the branch. Stay within scope though,
we're focusing first on the man pages and any user interaction. 
We'll get to docs later, that's gonna be a beast.

Guidelines
- Do not change any command names.
- *Do not change anything functional!!*
- If any command output includes the name of the tool, change it as
  appropriate or add something like "provided by OpenVox"
    - if the name is extraneous, then just remove it. For example in the
      message "cannot find puppet server" I just removed the word
      "puppet".
- When there is a reference to 'Puppet' that means 'the Puppet language'
  then change it to 'the Puppet language' to be more precise. (OpenVox
  implements the Puppet language. There's no such thing as an OpenVox
  language.)
- Do minor content editing for readability as appropriate.
- We are currently focusing only on user experience and branding. It
  should be very clear to a user that they're running the OpenVox
  implementation of Puppet. It's not yet important that all the internal
  and developer documentation or comments reflect this.
