### PR TITLE
adding ostruct and benchmark at their penultimate versions due to war…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ end
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ["~> 4.3"])
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
 gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 1.5"])
+gem 'ostruct', '~> 0.6.0'
+gem 'benchmark', '~> 0.3.0'
 
 group(:features) do
   gem 'diff-lcs', '~> 1.3', require: false


### PR DESCRIPTION
…nings at runtime and a future deprecation.

Warnings encountered:

util.rb:10: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0

util.rb:21: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0

Chanbges made:

added:

ostruct & benchmark