### PR TITLE
Make compressed man pages reproducible

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -87,7 +87,7 @@ def do_man(man, strip = 'man/')
     unless $osname == "Solaris"
       gzip = %x{which gzip}
       gzip.chomp!
-      %x{#{gzip} -fn #{omf}}
+      %x{#{gzip} --force --no-name #{omf}}
     end
   end
 end

--- a/install.rb
+++ b/install.rb
@@ -87,7 +87,7 @@ def do_man(man, strip = 'man/')
     unless $osname == "Solaris"
       gzip = %x{which gzip}
       gzip.chomp!
-      %x{#{gzip} -f #{omf}}
+      %x{#{gzip} -fn #{omf}}
     end
   end
 end


### PR DESCRIPTION
gzip(1) stores a timestamp in headers unless told not to do so: https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders