### PR TITLE
remove header in gzipped files

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -87,7 +87,7 @@ def do_man(man, strip = 'man/')
     unless $osname == "Solaris"
       gzip = %x{which gzip}
       gzip.chomp!
-      %x{#{gzip} -f #{omf}}
+      %x{#{gzip} -n -f #{omf}}
     end
   end
 end


### PR DESCRIPTION
Remove header in man pages when they are compress. It is a step for reproducible build.