### PR TITLE
Prevents spurious clientcert warnings in serverless mode

### DIFF
--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -97,12 +97,14 @@ class Puppet::SSL::SSLProvider
       cert_provider = Puppet::X509::CertProvider.new
       private_key = cert_provider.load_private_key(Puppet[:certname], required: false)
       unless private_key
-        Puppet.warning("Private key for '#{Puppet[:certname]}' does not exist")
+        msg = "Private key for '#{Puppet[:certname]}' does not exist"
+        Puppet.run_mode.name == :user ? Puppet.info(msg) : Puppet.warning(msg)
       end
 
       client_cert = cert_provider.load_client_cert(Puppet[:certname], required: false)
       unless client_cert
-        Puppet.warning("Client certificate for '#{Puppet[:certname]}' does not exist")
+        msg "Client certificate for '#{Puppet[:certname]}' does not exist"
+        Puppet.run_mode.name == :user ? Puppet.info(msg) : Puppet.warning(msg)
       end
 
       if private_key && client_cert


### PR DESCRIPTION
When there are no clientcerts, Puppet will warn when it creates an
`SSLContext` for HTTPS operations. This situation occurs when you run
entirely serverless and never generate clientcerts. It's spurious in
that case, so we don't actually need to warn about it.

This behaviour was added in https://github.com/OpenVoxProject/puppet/commit/3f7f830f0aef6fd3d1bf77a441d4000b9a586ed0
so that the new HTTP client could download files via HTTPS from the
puppetserver (for example, the way that pe_repo) works.

To prevent this being a failure when running `puppet apply` in
serverless mode, it explicitly marks the clientcerts as optional in
https://github.com/OpenVoxProject/puppet/blob/06bc441333c640678c9adb26412c6cb923af7f6b/lib/puppet/ssl/ssl_provider.rb#L98
and
https://github.com/OpenVoxProject/puppet/blob/06bc441333c640678c9adb26412c6cb923af7f6b/lib/puppet/ssl/ssl_provider.rb#L103

This goes one step further and sets the output to `INFO` rather than `WARN`
when running `puppet apply`.

This does have one small edge case. If,

1. You intend to run a standard server/agent setup, and
2. Before ever running `puppet agent -t` you run `puppet apply` for
   provisioning purposes, and
3. Part of that Puppet run attempts to download a file from the
   puppetserver

Then you will get a certificate validation error and the HTTPS request
will fail silently with only an `INFO` message as a hint explaining why.

To fix it, you obviously just generate and sign the clientcerts.

I think this is an acceptable tradeoff, but would like other opinions.
This will need specs before merging.

Fixes #21
