### PR TITLE
Fix unit test CSR versions for OpenSSL 3.4 change

### DIFF
--- a/spec/fixtures/ssl/generate_fixtures.rb
+++ b/spec/fixtures/ssl/generate_fixtures.rb
@@ -1,0 +1,54 @@
+# This will regenerate SSL fixtures.  It does not cover all fixtures yet.
+# Run it from the spec/fixtures/ssl directory.
+
+require_relative '../../lib/puppet_spec/ssl'
+
+def make_subject(name)
+  OpenSSL::X509::Name.new([["CN", name]])
+end
+
+def write_pem(content, path)
+  File.write(path, "#{content.to_text}\n#{content.to_pem}")
+  puts "Wrote #{content.class} to #{path}"
+end
+
+def read_pem(path, type)
+  text = File.read(path, encoding: 'UTF-8')
+  type.new(text)
+end
+
+def load_or_generate_key(path, size = nil)
+  if File.exist?(path)
+    puts "Loading RSA key from #{path}"
+    read_pem(path, OpenSSL::PKey::RSA)
+  else
+    puts "Generating new RSA key"
+    PuppetSpec::SSL.create_private_key(size)
+  end
+end
+
+def load_or_generate_csr(path, key = nil, name = nil)
+  if File.exist?(path)
+    puts "Loading CSR from #{path}"
+    return read_pem(path, OpenSSL::X509::Request)
+  end
+
+  raise "Must pass key and name parameters if CSR needs to be generated" unless key && name
+
+  csr = PuppetSpec::SSL.create_csr(key, "CN=#{name}")
+  puts "Generating new CSR for #{csr.subject}"
+  write_pem(csr, 'request.pem')
+end
+
+# Load or generate request-key.pem and request.pem
+req_key = load_or_generate_key('request-key.pem')
+req_csr = load_or_generate_csr('request.pem', req_key, 'pending')
+
+# Swap associated public key in request.pem to create a tampered CSR:
+unless File.exist?('tampered-csr.pem')
+  tampered_csr = load_or_generate_csr('request.pem')
+  tampered_csr.subject = make_subject('signed')
+  write_pem(tampered_csr, 'tampered-csr.pem')
+end
+
+puts "NOTE: Most fixtures are not yet able to be generated with this script"

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -1,6 +1,6 @@
 Certificate Request:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Subject: CN=pending
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -27,34 +27,36 @@ Certificate Request:
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
+        Requested Extensions:
     Signature Algorithm: sha256WithRSAEncryption
-         4b:33:bf:da:81:1a:39:41:11:c4:1c:d0:e5:3c:c6:93:8d:df:
-         e5:91:c4:9f:d0:6b:07:61:94:25:d8:dc:9e:99:0d:9d:96:91:
-         b3:92:ff:eb:2e:f4:93:cd:05:26:6d:42:70:7b:73:08:59:2f:
-         4f:c8:7f:5a:ea:de:84:a8:62:b9:6b:6c:24:0a:89:6c:83:66:
-         43:d2:f5:84:d2:09:63:9e:21:44:9f:70:4a:90:9e:9d:4a:e2:
-         e6:b1:62:79:0f:12:cf:f7:91:39:31:e6:24:ee:96:bc:82:5f:
-         4e:0e:a4:f3:81:75:6f:e3:59:bd:e2:8e:24:9e:3f:fd:c4:52:
-         81:f6:0d:95:31:36:48:0b:29:4e:94:22:10:a6:25:1f:f9:a7:
-         9d:e9:fc:8d:c9:33:87:1e:00:c9:f8:81:0e:d7:02:31:74:f7:
-         57:ef:31:06:b8:fd:10:d3:43:a5:e9:ee:47:83:05:ac:8a:69:
-         22:19:03:52:66:df:ee:0a:3c:82:33:23:9c:ef:c6:f2:e3:88:
-         9e:03:aa:c1:ab:92:e5:ca:b7:ab:e9:ab:40:ab:8f:73:53:69:
-         ca:19:89:8c:a5:e2:2f:9a:0b:31:59:17:08:03:4b:d5:6e:74:
-         5a:d0:c8:b8:df:d7:39:88:45:cb:6a:02:d4:41:1c:f2:1e:b9:
-         77:3f:09:80
+         83:dd:e5:75:b1:5b:15:6e:1e:b0:54:87:db:d0:c8:dd:12:a7:
+         42:1b:5e:b3:d0:4b:c3:d5:dc:70:6f:73:2a:09:1c:db:88:02:
+         93:20:d1:07:ee:dd:be:ab:a4:e7:e5:9f:de:ec:6a:ec:95:17:
+         1f:2d:89:85:42:b2:9c:e8:a5:d5:28:21:6a:83:33:a6:62:bd:
+         98:72:3d:63:db:94:08:21:4a:ad:d4:15:75:c1:f0:f4:30:d1:
+         f4:17:e8:e7:5f:74:e9:69:e7:33:77:9e:4b:92:4c:27:ee:4b:
+         bd:c1:e5:69:18:f3:55:37:11:c6:57:5b:61:22:24:bf:3a:1b:
+         c7:29:c0:72:50:3c:ce:4b:75:e4:64:16:8f:31:4d:19:04:95:
+         3b:61:f0:c3:ae:ac:2c:b9:f2:b4:10:c7:f0:e7:79:db:4a:37:
+         aa:63:3e:e6:b3:88:03:63:b8:1c:65:d6:3c:9f:d5:a6:43:49:
+         ed:e7:bb:f3:c4:9c:5b:aa:34:23:91:38:13:12:68:22:a2:cc:
+         f8:56:6c:8b:bc:f5:46:36:2b:2b:9c:b1:94:d0:09:59:fd:07:
+         c7:62:74:aa:ee:f8:1b:0d:83:05:37:43:4d:d4:0b:c9:a4:57:
+         9d:91:ce:9b:5b:5f:6f:87:12:02:69:f7:43:6d:05:f3:6b:e8:
+         f2:a5:9f:6b
+
 -----BEGIN CERTIFICATE REQUEST-----
-MIICVzCCAT8CAQIwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
+MIICVzCCAT8CAQAwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
 BQADggEPADCCAQoCggEBAMpK/Enwdd7bcYiH90jsd2d8OKSRJEekhRw45Oxtiqok
 jfscQcqW15JwFJ3MpybVkQSHw5u8fMJ9X41QddYCUaM4lLi4Y0s4zwgLwDHZptth
 txEylcqH3FQh0btWuSzyxoQfVN8J0VCdrpdF+cBmWNljPvu/r+YayO6Ea81Q/tx6
 UnQXPDWJS6dIO7iErtEMPFzg40wg+KqkcE4QFV6lbm+Zh/15RUAra+zjNnrtcwIo
 x8suoMo0BTH1mMknQObj8yYqJcyJUoegM6VhosZzvaf8pguTRv47p2+jO6RtHhvR
 xCgJ6h20qvOa+xCisiHyhnCkuKjfTAks+9JIqRw6TRcCAwEAAaAAMA0GCSqGSIb3
-DQEBCwUAA4IBAQBLM7/agRo5QRHEHNDlPMaTjd/lkcSf0GsHYZQl2NyemQ2dlpGz
-kv/rLvSTzQUmbUJwe3MIWS9PyH9a6t6EqGK5a2wkColsg2ZD0vWE0gljniFEn3BK
-kJ6dSuLmsWJ5DxLP95E5MeYk7pa8gl9ODqTzgXVv41m94o4knj/9xFKB9g2VMTZI
-CylOlCIQpiUf+aed6fyNyTOHHgDJ+IEO1wIxdPdX7zEGuP0Q00Ol6e5HgwWsimki
-GQNSZt/uCjyCMyOc78by44ieA6rBq5Llyrer6atAq49zU2nKGYmMpeIvmgsxWRcI
-A0vVbnRa0Mi439c5iEXLagLUQRzyHrl3PwmA
+DQEBCwUAA4IBAQCD3eV1sVsVbh6wVIfb0MjdEqdCG16z0EvD1dxwb3MqCRzbiAKT
+INEH7t2+q6Tn5Z/e7GrslRcfLYmFQrKc6KXVKCFqgzOmYr2Ycj1j25QIIUqt1BV1
+wfD0MNH0F+jnX3Tpaeczd55Lkkwn7ku9weVpGPNVNxHGV1thIiS/OhvHKcByUDzO
+S3XkZBaPMU0ZBJU7YfDDrqwsufK0EMfw53nbSjeqYz7ms4gDY7gcZdY8n9WmQ0nt
+57vzxJxbqjQjkTgTEmgiosz4VmyLvPVGNisrnLGU0AlZ/QfHYnSq7vgbDYMFN0NN
+1AvJpFedkc6bW19vhxICafdDbQXza+jypZ9r
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -1,60 +1,62 @@
 Certificate Request:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ca:3c:49:ca:69:e4:42:bc:a6:01:37:4e:c6:6c:
-                    1e:a9:d3:b1:7d:20:b6:7f:a9:74:c2:ce:33:f8:32:
-                    85:50:8a:c4:da:d6:47:2c:8e:3e:ef:9e:14:42:b3:
-                    43:b9:9f:59:ca:18:2c:32:f8:f8:5d:c6:74:1b:29:
-                    27:f8:d0:90:05:2e:03:46:b3:a2:c2:9d:38:de:06:
-                    f6:30:52:ff:e5:26:6e:88:fc:c4:23:32:f3:d3:09:
-                    67:1d:a6:52:f1:cc:06:28:2b:4e:af:7b:b2:50:a9:
-                    4f:7f:9b:62:6b:5a:cb:8c:f6:7e:ae:ed:a2:f2:4f:
-                    0d:d2:f5:42:2e:d8:50:b8:0f:fc:38:cd:80:7d:2a:
-                    d8:fc:76:e6:f7:28:91:f9:59:a7:d7:81:88:78:5c:
-                    74:0c:82:9b:14:65:35:2d:04:69:53:24:e4:c2:37:
-                    96:36:61:0b:e0:0f:2c:ac:50:85:84:ca:68:df:a4:
-                    15:2a:b0:a3:03:50:1f:11:45:d4:82:6a:02:eb:76:
-                    8b:82:1c:36:2b:8c:7e:3b:a6:12:c4:5a:8a:20:ab:
-                    2d:08:f8:49:1b:d6:f9:45:dc:d8:34:6c:8c:7b:2d:
-                    2a:8a:c6:87:d0:6a:45:20:9d:f0:43:d0:0f:0a:a2:
-                    69:d6:9b:a1:69:9c:57:e8:b2:f8:56:8f:f6:e4:24:
-                    af:c1
+                    00:ca:4a:fc:49:f0:75:de:db:71:88:87:f7:48:ec:
+                    77:67:7c:38:a4:91:24:47:a4:85:1c:38:e4:ec:6d:
+                    8a:aa:24:8d:fb:1c:41:ca:96:d7:92:70:14:9d:cc:
+                    a7:26:d5:91:04:87:c3:9b:bc:7c:c2:7d:5f:8d:50:
+                    75:d6:02:51:a3:38:94:b8:b8:63:4b:38:cf:08:0b:
+                    c0:31:d9:a6:db:61:b7:11:32:95:ca:87:dc:54:21:
+                    d1:bb:56:b9:2c:f2:c6:84:1f:54:df:09:d1:50:9d:
+                    ae:97:45:f9:c0:66:58:d9:63:3e:fb:bf:af:e6:1a:
+                    c8:ee:84:6b:cd:50:fe:dc:7a:52:74:17:3c:35:89:
+                    4b:a7:48:3b:b8:84:ae:d1:0c:3c:5c:e0:e3:4c:20:
+                    f8:aa:a4:70:4e:10:15:5e:a5:6e:6f:99:87:fd:79:
+                    45:40:2b:6b:ec:e3:36:7a:ed:73:02:28:c7:cb:2e:
+                    a0:ca:34:05:31:f5:98:c9:27:40:e6:e3:f3:26:2a:
+                    25:cc:89:52:87:a0:33:a5:61:a2:c6:73:bd:a7:fc:
+                    a6:0b:93:46:fe:3b:a7:6f:a3:3b:a4:6d:1e:1b:d1:
+                    c4:28:09:ea:1d:b4:aa:f3:9a:fb:10:a2:b2:21:f2:
+                    86:70:a4:b8:a8:df:4c:09:2c:fb:d2:48:a9:1c:3a:
+                    4d:17
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
+        Requested Extensions:
     Signature Algorithm: sha256WithRSAEncryption
-         9f:1b:09:61:fd:59:7a:99:8d:c3:f3:44:44:10:af:ac:82:f6:
-         20:5e:5e:3d:e3:07:af:e7:f6:0e:31:1f:ae:7e:bc:fd:4c:db:
-         53:8c:6b:6b:ea:76:e7:96:2c:21:f7:e7:ac:ff:ce:47:ec:e3:
-         61:c2:40:3a:0a:58:ac:94:80:c2:24:25:c3:75:82:8a:60:aa:
-         c6:20:8a:b6:28:b6:97:56:7e:0c:92:d8:da:2f:e0:0e:59:6d:
-         e1:55:b0:01:a1:e7:a9:bc:57:a1:50:de:b3:47:8a:cc:2c:44:
-         cd:5a:9b:bf:64:d3:aa:f9:b1:b2:55:db:c6:6f:5a:6c:54:19:
-         8b:4d:b2:9c:54:e0:2b:6e:c7:8c:26:d4:8d:c7:6c:43:8d:3b:
-         d1:12:87:c2:ca:ba:49:1f:93:eb:e2:8a:a9:7c:7d:e6:32:f6:
-         78:83:ab:54:9b:47:d1:c1:c2:bb:b4:25:b0:9d:bb:29:40:db:
-         30:7f:9a:4d:7a:94:5b:a0:1d:33:99:0e:9a:02:f3:4f:a4:82:
-         dd:47:15:f6:76:03:14:9f:60:9e:89:1a:4f:04:fa:a8:23:49:
-         48:af:65:bd:8c:3a:0f:77:fa:c3:86:d4:87:1a:9c:94:61:28:
-         0b:72:2e:91:98:19:0b:fe:9a:93:45:2a:92:a7:93:83:89:d9:
-         93:6b:d5:ee
+         83:dd:e5:75:b1:5b:15:6e:1e:b0:54:87:db:d0:c8:dd:12:a7:
+         42:1b:5e:b3:d0:4b:c3:d5:dc:70:6f:73:2a:09:1c:db:88:02:
+         93:20:d1:07:ee:dd:be:ab:a4:e7:e5:9f:de:ec:6a:ec:95:17:
+         1f:2d:89:85:42:b2:9c:e8:a5:d5:28:21:6a:83:33:a6:62:bd:
+         98:72:3d:63:db:94:08:21:4a:ad:d4:15:75:c1:f0:f4:30:d1:
+         f4:17:e8:e7:5f:74:e9:69:e7:33:77:9e:4b:92:4c:27:ee:4b:
+         bd:c1:e5:69:18:f3:55:37:11:c6:57:5b:61:22:24:bf:3a:1b:
+         c7:29:c0:72:50:3c:ce:4b:75:e4:64:16:8f:31:4d:19:04:95:
+         3b:61:f0:c3:ae:ac:2c:b9:f2:b4:10:c7:f0:e7:79:db:4a:37:
+         aa:63:3e:e6:b3:88:03:63:b8:1c:65:d6:3c:9f:d5:a6:43:49:
+         ed:e7:bb:f3:c4:9c:5b:aa:34:23:91:38:13:12:68:22:a2:cc:
+         f8:56:6c:8b:bc:f5:46:36:2b:2b:9c:b1:94:d0:09:59:fd:07:
+         c7:62:74:aa:ee:f8:1b:0d:83:05:37:43:4d:d4:0b:c9:a4:57:
+         9d:91:ce:9b:5b:5f:6f:87:12:02:69:f7:43:6d:05:f3:6b:e8:
+         f2:a5:9f:6b
+
 -----BEGIN CERTIFICATE REQUEST-----
-MIICVjCCAT4CAQIwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAyjxJymnkQrymATdOxmweqdOxfSC2f6l0ws4z+DKFUIrE
-2tZHLI4+754UQrNDuZ9ZyhgsMvj4XcZ0Gykn+NCQBS4DRrOiwp043gb2MFL/5SZu
-iPzEIzLz0wlnHaZS8cwGKCtOr3uyUKlPf5tia1rLjPZ+ru2i8k8N0vVCLthQuA/8
-OM2AfSrY/Hbm9yiR+Vmn14GIeFx0DIKbFGU1LQRpUyTkwjeWNmEL4A8srFCFhMpo
-36QVKrCjA1AfEUXUgmoC63aLghw2K4x+O6YSxFqKIKstCPhJG9b5RdzYNGyMey0q
-isaH0GpFIJ3wQ9APCqJp1puhaZxX6LL4Vo/25CSvwQIDAQABoAAwDQYJKoZIhvcN
-AQELBQADggEBAJ8bCWH9WXqZjcPzREQQr6yC9iBeXj3jB6/n9g4xH65+vP1M21OM
-a2vqdueWLCH356z/zkfs42HCQDoKWKyUgMIkJcN1gopgqsYgirYotpdWfgyS2Nov
-4A5ZbeFVsAGh56m8V6FQ3rNHiswsRM1am79k06r5sbJV28ZvWmxUGYtNspxU4Ctu
-x4wm1I3HbEONO9ESh8LKukkfk+viiql8feYy9niDq1SbR9HBwru0JbCduylA2zB/
-mk16lFugHTOZDpoC80+kgt1HFfZ2AxSfYJ6JGk8E+qgjSUivZb2MOg93+sOG1Ica
-nJRhKAtyLpGYGQv+mpNFKpKnk4OJ2ZNr1e4=
+MIICVjCCAT4CAQAwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAykr8SfB13ttxiIf3SOx3Z3w4pJEkR6SFHDjk7G2KqiSN
++xxBypbXknAUncynJtWRBIfDm7x8wn1fjVB11gJRoziUuLhjSzjPCAvAMdmm22G3
+ETKVyofcVCHRu1a5LPLGhB9U3wnRUJ2ul0X5wGZY2WM++7+v5hrI7oRrzVD+3HpS
+dBc8NYlLp0g7uISu0Qw8XODjTCD4qqRwThAVXqVub5mH/XlFQCtr7OM2eu1zAijH
+yy6gyjQFMfWYySdA5uPzJiolzIlSh6AzpWGixnO9p/ymC5NG/junb6M7pG0eG9HE
+KAnqHbSq85r7EKKyIfKGcKS4qN9MCSz70kipHDpNFwIDAQABoAAwDQYJKoZIhvcN
+AQELBQADggEBAIPd5XWxWxVuHrBUh9vQyN0Sp0IbXrPQS8PV3HBvcyoJHNuIApMg
+0Qfu3b6rpOfln97sauyVFx8tiYVCspzopdUoIWqDM6ZivZhyPWPblAghSq3UFXXB
+8PQw0fQX6OdfdOlp5zN3nkuSTCfuS73B5WkY81U3EcZXW2EiJL86G8cpwHJQPM5L
+deRkFo8xTRkElTth8MOurCy58rQQx/DnedtKN6pjPuaziANjuBxl1jyf1aZDSe3n
+u/PEnFuqNCOROBMSaCKizPhWbIu89UY2KyucsZTQCVn9B8didKru+BsNgwU3Q03U
+C8mkV52RzptbX2+HEgJp90NtBfNr6PKln2s=
 -----END CERTIFICATE REQUEST-----

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -34,7 +34,7 @@ module Puppet
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
       csr.subject = OpenSSL::X509::Name.new([["CN", name]])
-      csr.version = 2
+      csr.version = 0
       csr.sign(key, @digest)
       { private_key: key, csr: csr }
     end

--- a/spec/lib/puppet_spec/ssl.rb
+++ b/spec/lib/puppet_spec/ssl.rb
@@ -61,7 +61,7 @@ EOT
 
       csr.public_key = key.public_key
       csr.subject = OpenSSL::X509::Name.parse(name)
-      csr.version = 2
+      csr.version = 0
       csr.sign(key, DEFAULT_SIGNING_DIGEST)
 
       csr

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -314,6 +314,7 @@ describe Puppet::SSL::CertificateRequest do
     it "should use SHA1 to sign the csr when SHA256 isn't available" do
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
+      csr.version = 0
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(true)
       signer = Puppet::SSL::CertificateSigner.new
@@ -325,6 +326,7 @@ describe Puppet::SSL::CertificateRequest do
       key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
+      csr.version = 0
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(true)
@@ -337,6 +339,7 @@ describe Puppet::SSL::CertificateRequest do
       key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
+      csr.version = 0
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(false)
@@ -349,6 +352,7 @@ describe Puppet::SSL::CertificateRequest do
     it "should use SHA224 to sign the csr when SHA256/SHA1/SHA512/SHA384 aren't available" do
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
+      csr.version = 0
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(false)


### PR DESCRIPTION
The only valid CSR version is version 1, which is encoded with "csr.version = 0". Versions of OpenSSL prior to 3.4 would allow other versions to be set / versions to be unset but OpenSSL 3.4 is strict about only allowing version 1.

This change updates the unit tests and test fixtures to all specify or contain version 1 CSRs.