### PR TITLE
Fix given_or_derived behavior in Pops object init_hash

### DIFF
--- a/lib/puppet/pops/types/p_object_type.rb
+++ b/lib/puppet/pops/types/p_object_type.rb
@@ -876,7 +876,7 @@ class PObjectType < PMetaType
     struct_elems = {}
     attributes(true).values.each do |attr|
       unless attr.kind == ATTRIBUTE_KIND_CONSTANT || attr.kind == ATTRIBUTE_KIND_DERIVED
-        if attr.value?
+        if attr.value? || attr.kind == ATTRIBUTE_KIND_GIVEN_OR_DERIVED
           struct_elems[TypeFactory.optional(attr.name)] = attr.type
         else
           struct_elems[attr.name] = attr.type

--- a/spec/unit/pops/types/p_object_type_spec.rb
+++ b/spec/unit/pops/types/p_object_type_spec.rb
@@ -697,18 +697,16 @@ describe 'The Object Type' do
   end
 
   context 'when producing an init_hash_type' do
-    it 'produces a struct of all attributes that are not derived or constant' do
+    it 'produces a struct of all attributes excepting derived or constant' do
       t = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer },
-          b => { type => Integer, kind => given_or_derived },
-          c => { type => Integer, kind => derived },
-          d => { type => Integer, kind => constant, value => 4 }
+          b => { type => Integer, kind => derived },
+          c => { type => Integer, kind => constant, value => 4 }
         }
       OBJECT
       expect(t.init_hash_type).to eql(factory.struct({
         'a' => factory.integer,
-        'b' => factory.integer
       }))
     end
 
@@ -716,12 +714,14 @@ describe 'The Object Type' do
       t = parse_object('MyObject', <<-OBJECT)
         attributes => {
           a => { type => Integer },
-          b => { type => Integer, value => 4 }
+          b => { type => Integer, value => 4 },
+          c => { type => Integer, kind => given_or_derived },
         }
       OBJECT
       expect(t.init_hash_type).to eql(factory.struct({
         'a' => factory.integer,
-        factory.optional('b') => factory.integer
+        factory.optional('b') => factory.integer,
+        factory.optional('c') => factory.integer,
       }))
     end
 


### PR DESCRIPTION
In create_init_hash_type the type specification for an init hash is built.  Currently a given_or_derived type is always defined as a required init_hash attribute, which defeats the ability to leave it unspecified and use the derived value defaults.

By defining given_or_derived types always as optional it allows passing a value in the init_hash or leaving it out and using the derived value.