### PR TITLE
Update util.rb to fix closing of file.

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -481,7 +481,7 @@ module Util
         Dir.foreach('/proc/self/fd') do |f|
           if f != '.' && f != '..' && f.to_i >= 3
             begin
-              IO.new(f.to_i).close
+              IO.new(f).close
             rescue
               nil
             end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -479,9 +479,9 @@ module Util
 
       begin
         Dir.foreach('/proc/self/fd') do |f|
-          if f != '.' && f != '..' && f.to_i >= 3
+          if %{^\d+$}.match?(f) && f.to_i >= 3
             begin
-              IO.new(f).close
+              IO.new(f.to_i).close
             rescue
               nil
             end


### PR DESCRIPTION
When attempting to close files, the /proc/self loop was trying to close a file being converted to an integer which was causing issues on Fedora 42, this resolved the problem.

Also see https://github.com/puppetlabs/puppet/pull/9552