### PR TITLE
Avoid closing directory we're iterating

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -479,7 +479,7 @@ module Util
 
       begin
         Dir.foreach('/proc/self/fd') do |f|
-          if %{^\d+$}.match?(f) && f.to_i >= 3
+          if f != '.' && f != '..' && f.to_i >= 3
             begin
               IO.new(f.to_i).close
             rescue

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -481,12 +481,12 @@ module Util
         d = Dir.new('/proc/self/fd')
         ignore_fds = ['.', '..', d.fileno.to_s]
         d.each_child do |f|
-          if !ignore_fds.include?(f) && f.to_i >= 3
-            begin
-              IO.new(f.to_i).close
-            rescue
-              nil
-            end
+          next if ignore_fds.include?(f) || f.to_i < 3
+
+          begin
+            IO.new(f.to_i).close
+          rescue
+            nil
           end
         end
       rescue Errno::ENOENT, Errno::ENOTDIR # /proc/self/fd not found, /proc/self not a dir

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -478,8 +478,10 @@ module Util
       $stderr = STDERR
 
       begin
-        Dir.foreach('/proc/self/fd') do |f|
-          if f != '.' && f != '..' && f.to_i >= 3
+        d = Dir.new('/proc/self/fd')
+        ignore_fds = ['.', '..', d.fileno.to_s]
+        d.each_child do |f|
+          if !ignore_fds.include?(f) && f.to_i >= 3
             begin
               IO.new(f.to_i).close
             rescue


### PR DESCRIPTION
This starts with reverting #39 because [it's broken](https://github.com/OpenVoxProject/puppet/pull/39#issuecomment-2840341655) and caused a regression. Then   I've taken my commits from https://github.com/puppetlabs/puppet/pull/9546.

Ruby 3.4 started error checking directory access and starts to raise Errno::EBADF.

This particular loop iterates on all open file descriptors and one is the directory listing from Dir.foreach.

In the past this could have led to leaked file descriptors, but it's unlikely since it's likely the last opened file descriptor and have the highest number.

Link: https://github.com/ruby/ruby/commit/f2919bd11c570fc5f5440d1f101be38f61e3d16b
Link: https://bugzilla.redhat.com/show_bug.cgi?id=2349352