### PR TITLE
Fix a typo and some formatting in the type and provider docs

### DIFF
--- a/lib/puppet/provider/package/tdnf.rb
+++ b/lib/puppet/provider/package/tdnf.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:package).provide :tdnf, :parent => :dnf do
   desc "Support via `tdnf`.
 
   This provider supports the `install_options` attribute, which allows command-line flags to be passed to tdnf.
-  These options should be spcified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}), or an
+  These options should be specified as a string (e.g. `'--flag'`), a hash (e.g. `{'--flag' => 'value'}`), or an
   array where each element is either a string or a hash."
 
   has_feature :install_options, :versionable, :virtual_packages

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -291,15 +291,15 @@ module Puppet
       desc <<-EOT
         The targeted command to use when managing a package:
 
-          package { 'mysql':
-            provider => gem,
-          }
+            package { 'mysql':
+              provider => gem,
+            }
 
-          package { 'mysql-opt':
-            name     => 'mysql',
-            provider => gem,
-            command  => '/opt/ruby/bin/gem',
-          }
+            package { 'mysql-opt':
+              name     => 'mysql',
+              provider => gem,
+              command  => '/opt/ruby/bin/gem',
+            }
 
         Each provider defines a package management command and uses the first
         instance of the command found in the PATH.

--- a/references/type.md
+++ b/references/type.md
@@ -2063,15 +2063,15 @@ _(**Namevar:** If omitted, this attribute's value defaults to the resource's tit
 
 The targeted command to use when managing a package:
 
-  package { 'mysql':
-    provider => gem,
-  }
+    package { 'mysql':
+      provider => gem,
+    }
 
-  package { 'mysql-opt':
-    name     => 'mysql',
-    provider => gem,
-    command  => '/opt/ruby/bin/gem',
-  }
+    package { 'mysql-opt':
+      name     => 'mysql',
+      provider => gem,
+      command  => '/opt/ruby/bin/gem',
+    }
 
 Each provider defines a package management command and uses the first
 instance of the command found in the PATH.
@@ -2795,7 +2795,7 @@ has not actually been tested.
 Support via `tdnf`.
 
 This provider supports the `install_options` attribute, which allows command-line flags to be passed to tdnf.
-These options should be spcified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}), or an
+These options should be specified as a string (e.g. `'--flag'`), a hash (e.g. `{'--flag' => 'value'}`), or an
 array where each element is either a string or a hash.
 
 * Required binaries: `rpm`, `tdnf`.

--- a/references/types/package.md
+++ b/references/types/package.md
@@ -80,15 +80,15 @@ _(**Namevar:** If omitted, this attribute's value defaults to the resource's tit
 
 The targeted command to use when managing a package:
 
-  package { 'mysql':
-    provider => gem,
-  }
+    package { 'mysql':
+      provider => gem,
+    }
 
-  package { 'mysql-opt':
-    name     => 'mysql',
-    provider => gem,
-    command  => '/opt/ruby/bin/gem',
-  }
+    package { 'mysql-opt':
+      name     => 'mysql',
+      provider => gem,
+      command  => '/opt/ruby/bin/gem',
+    }
 
 Each provider defines a package management command and uses the first
 instance of the command found in the PATH.
@@ -942,7 +942,7 @@ has not actually been tested.
 Support via `tdnf`.
 
 This provider supports the `install_options` attribute, which allows command-line flags to be passed to tdnf.
-These options should be spcified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}), or an
+These options should be specified as a string (e.g. `'--flag'`), a hash (e.g. `{'--flag' => 'value'}`), or an
 array where each element is either a string or a hash.
 
 * Required binaries: `rpm`, `tdnf`


### PR DESCRIPTION
This patch fixes a typo (letter 'e' missing) and updates the indentation of a code example from two to four spaces.  This ensures the example is formatted as code in the generated markdown version.