### PR TITLE
Remove require for module_tool/contents_description

### DIFF
--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -188,7 +188,6 @@ end
 require_relative 'module_tool/errors'
 require_relative 'module_tool/applications'
 require_relative 'module_tool/checksums'
-require_relative 'module_tool/contents_description'
 require_relative 'module_tool/dependency'
 require_relative 'module_tool/metadata'
 require_relative '../puppet/forge/cache'


### PR DESCRIPTION
When removing the ContentsDescription class I forgot the require statement.

Fixes: 13cd2f5cfebbf18bb6da4dbdd36dcfff5ea49dac ("Remove unused ContentsDescription class")