### PR TITLE
Add 'implementation' fact to agent and server.

### DIFF
--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -28,6 +28,7 @@ class Puppet::Node::Facts
   attr_accessor :name, :values, :timestamp
 
   def add_local_facts
+    values["implementation"] = "openvox"
     values["clientcert"] = Puppet.settings[:certname]
     values["clientversion"] = Puppet.version.to_s
     values["clientnoop"] = Puppet.settings[:noop]

--- a/lib/puppet/node/server_facts.rb
+++ b/lib/puppet/node/server_facts.rb
@@ -4,6 +4,9 @@ class Puppet::Node::ServerFacts
   def self.load
     server_facts = {}
 
+    # Add implementation information
+    server_facts["implementation"] = "openvox"
+
     # Add our server Puppet Enterprise version, if available.
     pe_version_file = '/opt/puppetlabs/server/pe_version'
     if File.readable?(pe_version_file) and !File.zero?(pe_version_file)

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -35,6 +35,12 @@ describe Puppet::Node::Facts, "when indirecting" do
       @facts.add_local_facts
       expect(@facts.values["environment"]).to eq("foo")
     end
+
+    it "adds the implementation fact" do
+      @facts.add_local_facts
+      expect(@facts.values).to include("implementation")
+      expect(@facts.values["implementation"]).to eq("openvox")
+    end
   end
 
   describe "when sanitizing facts" do


### PR DESCRIPTION
As specified in OpenVoxProject/planning#39, the agent will now make its implementation flavor known to the compiler through a built-in fact, as will the server (through a server fact).