### PR TITLE
Support both puppet and openvox gem names

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -1,0 +1,1 @@
+puppet.gemspec

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |spec|
-  spec.name = "openvox"
+  spec.name = File.basename(__FILE__, '.gemspec')
   spec.version = "8.18.1"
   spec.licenses = ['Apache-2.0']
 


### PR DESCRIPTION
This uses the filename to determine the gem name. This allows users to choose:

```ruby
gem 'puppet', github: 'OpenVoxProject/puppet'
```

Or use the new openvox gem:

```ruby
gem 'openvox', github: 'OpenVoxProject/puppet'
```

At some point they can start to diverge and make puppet more of a transitional gem that only depends on openvox.

Currently untested, but this allows for discussion.