### PR TITLE
Replace erase with remove, since it's no longer supported with dnf5

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -345,7 +345,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   end
 
   def purge
-    execute([command(:cmd), "-y", :erase, @resource[:name]])
+    execute([command(:cmd), "-y", :remove, @resource[:name]])
   end
 
   private

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -189,8 +189,8 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
     end
 
     describe 'when uninstalling' do
-      it 'should use erase to purge' do
-        expect(Puppet::Util::Execution).to receive(:execute).with(["/usr/bin/#{provider_name}", '-y', :erase, name])
+      it 'should use remove to purge' do
+        expect(Puppet::Util::Execution).to receive(:execute).with(["/usr/bin/#{provider_name}", '-y', :remove, name])
         provider.purge
       end
     end


### PR DESCRIPTION
From the dnf4 [manpage](https://www.man7.org/linux/man-pages/man8/dnf4.8.html):
```
   Remove Command
       Command: remove
       Aliases: rm
       Aliases for explicit NEVRA matching: remove-n, remove-na, remove-nevra
       Deprecated aliases: erase, erase-n, erase-na, erase-nevra
```

Resulting in this error on fedora 42, which has dnf5:
```
Error: Execution of '/usr/sbin/dnf -y erase pipewire-libs' returned 2: Unknown argument "erase" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf5 install 'dnf5-command(erase)'
```

I tested it by replacing `erase` with `remove` in `/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/provider/package/yum.rb` and the package was properly removed.

This is analogous to PR #28