### PR TITLE
rubocop: load plugins as actual plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
+---
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-i18n
   - rubocop-performance
   - rubocop-rake


### PR DESCRIPTION
when they are loaded via `require`, they will log a bunch of warnings into CI:

```
rubocop-i18n extension supports plugin, specify `plugins: rubocop-i18n` instead of `require: rubocop-i18n` in /home/runner/work/puppet/puppet/.rubocop.yml.
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /home/runner/work/puppet/puppet/.rubocop.yml.
rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in /home/runner/work/puppet/puppet/.rubocop.yml.
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /home/runner/work/puppet/puppet/.rubocop.yml.
```