### PR TITLE
Adjust test for different formatting on Ruby 3.4

### DIFF
--- a/spec/unit/functions/join_spec.rb
+++ b/spec/unit/functions/join_spec.rb
@@ -24,7 +24,11 @@ describe 'the join function' do
   end
 
   it 'does not flatten arrays nested in hashes' do
-    expect(compile_to_catalog("notify { join([1,2,{a => [3,4]}]): }")).to have_resource('Notify[12{"a"=>[3, 4]}]')
+    if Gem::Requirement.create(['>= 3.4.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+      expect(compile_to_catalog("notify { join([1,2,{a => [3,4]}]): }")).to have_resource('Notify[12{"a" => [3, 4]}]')
+    else
+      expect(compile_to_catalog("notify { join([1,2,{a => [3,4]}]): }")).to have_resource('Notify[12{"a"=>[3, 4]}]')
+    end
   end
 
   it 'formats nil/undef as empty string' do


### PR DESCRIPTION
Ruby 3.4 uses a newer json lib and formats json with more whitespace.