### PR TITLE
Generate human-readable ChangeLog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,3 +29,13 @@ jobs:
           chmod 0600 ~/.gem/credentials
       - name: Publish gem to GitHub packages
         run: gem push --key github --host https://rubygems.pkg.github.com/openvoxproject *.gem
+      - name: Create Release Page
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }} --generate-notes
+      - name: Attach gem to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload ${{ github.ref_name }} pkg/*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group(:development, optional: true) do
 end
 
 group(:packaging) do
+  gem 'github_changelog_generator'
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -146,3 +146,19 @@ if Rake.application.top_level_tasks.grep(/^gettext:/).any?
     abort("Run `bundle install --with documentation` to install the `gettext-setup` gem.")
   end
 end
+
+require "github_changelog_generator/task"
+require_relative "lib/puppet/version"
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.header = <<~HEADER.chomp
+    # Changelog
+
+    All notable changes to this project will be documented in this file.
+  HEADER
+  config.user = "openvoxproject"
+  config.project = "puppet"
+  config.exclude_labels = %w[dependencies duplicate question invalid wontfix wont-fix modulesync skip-changelog]
+  config.since_tag = "8.18.1"
+  config.future_release = Puppet::PUPPETVERSION
+end

--- a/Rakefile
+++ b/Rakefile
@@ -147,18 +147,24 @@ if Rake.application.top_level_tasks.grep(/^gettext:/).any?
   end
 end
 
-require "github_changelog_generator/task"
-require_relative "lib/puppet/version"
+begin
+  require "github_changelog_generator/task"
+  require_relative "lib/puppet/version"
 
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.header = <<~HEADER.chomp
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.header = <<~HEADER.chomp
     # Changelog
 
     All notable changes to this project will be documented in this file.
-  HEADER
-  config.user = "openvoxproject"
-  config.project = "puppet"
-  config.exclude_labels = %w[dependencies duplicate question invalid wontfix wont-fix modulesync skip-changelog]
-  config.since_tag = "8.18.1"
-  config.future_release = Puppet::PUPPETVERSION
+    HEADER
+    config.user = "openvoxproject"
+    config.project = "puppet"
+    config.exclude_labels = %w[dependencies duplicate question invalid wontfix wont-fix modulesync skip-changelog]
+    config.since_tag = "8.18.1"
+    config.future_release = Puppet::PUPPETVERSION
+  end
+rescue LoadError
+  task :changelog do
+    abort("Run `bundle install --with packaging` to install the `github_changelog_generator` gem.")
+  end
 end

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,6 +1,8 @@
+require_relative 'lib/puppet/version'
+
 Gem::Specification.new do |spec|
   spec.name = "openvox"
-  spec.version = "8.18.1"
+  spec.version = Puppet::PUPPETVERSION
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")


### PR DESCRIPTION
In the Vox Pupuli tradition, use labels in GitHub issues to generate a human readable changelog when we release a new version of the code.

Also create a release page, and attach the gem to it.

I really like the way puppetlabs ci has a release preparation action that set version and update the changelog to allow a review. This is more work that what I can afford ATM, but we can go in that direction in the future.
