### PR TITLE
Update release default lables

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,40 @@
+---
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
 changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - modulesync
+      - question
+      - skip-changelog
+      - wont-fix
+      - wontfix
+      - github_actions
+
   categories:
-    - title: Features & Enhancements
+    - title: Breaking Changes 🛠
+      labels:
+        - backwards-incompatible
+
+    - title: New Features 🎉
       labels:
         - enhancement
-    - title: Bug Fixes
+
+    - title: Bug Fixes 🐛
       labels:
         - bug
+
+    - title: Documentation Updates 📚
+      labels:
+        - documentation
+        - docs
+
+    - title: Dependency Updates ⬆️
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
We use the same config in our other Vox Pupuli projects. For example https://github.com/voxpupuli/modulesync_config/blob/master/.github/release.yml