### PR TITLE
Add racc gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group(:test) do
   # 1.16.0 - 1.16.2 are broken on Windows
   gem 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2', require: false
   gem "json-schema", '>= 2', '< 6', require: false
-  gem "racc", "1.5.2", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 13.0')
   gem "rspec", "~> 3.1", require: false
   gem "rspec-expectations", ["~> 3.9", "!= 3.9.3"]

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
   spec.add_runtime_dependency('ostruct', '~> 0.6.0')
   spec.add_runtime_dependency('benchmark', '>= 0.3', '< 0.5')
+  spec.add_runtime_dependency('racc', '~> 1.5')
 
 
   platform = spec.platform.to_s


### PR DESCRIPTION
racc came as a default gem in Ruby < 3.3 but after that it became a bundled gem. This means it must be listed as a proper dependency.