### PR TITLE
Fix invalid gemspec in AIO package

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,8 +1,6 @@
-require_relative 'lib/puppet/version'
-
 Gem::Specification.new do |spec|
   spec.name = "openvox"
-  spec.version = Puppet::PUPPETVERSION
+  spec.version = "8.18.1"
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")


### PR DESCRIPTION
This reverts commit bf87d142f2643e05c4c5564ad6eb732e8331cef7.

When building a gem, this file is processed by the gem(1) command and
the installed file is the result of a bunch of substitutions.

However, when building AIO packages, the file is copied as is, and
a relative path will not work properly.  This result in a flood of
warnings about invalid gemspec:

```
Invalid gemspec in [/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/specifications/puppet-8.19.0.gemspec]: cannot load such file -- /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/specifications/lib/puppet/version
```
