### PR TITLE
Add base64 and syslog as gem dependencies for Ruby 3.4

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.summary = "OpenVox, a community implementation of Puppet -- an automated configuration management tool"
   spec.specification_version = 4
+  spec.add_runtime_dependency('benchmark', '>= 0.3', '< 0.5')
   spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
   spec.add_runtime_dependency('deep_merge', '~> 1.0')
   spec.add_runtime_dependency('facter', ['>= 4.3.0', '< 5'])
@@ -27,13 +28,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('getoptlong', '~> 0.2.0')
   spec.add_runtime_dependency('locale', '~> 2.1')
   spec.add_runtime_dependency('multi_json', '~> 1.13')
+  spec.add_runtime_dependency('ostruct', '~> 0.6.0')
   spec.add_runtime_dependency('puppet-resource_api', '~> 1.5')
+  spec.add_runtime_dependency('racc', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
-  spec.add_runtime_dependency('ostruct', '~> 0.6.0')
-  spec.add_runtime_dependency('benchmark', '>= 0.3', '< 0.5')
-  spec.add_runtime_dependency('racc', '~> 1.5')
-
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.summary = "OpenVox, a community implementation of Puppet -- an automated configuration management tool"
   spec.specification_version = 4
+  spec.add_runtime_dependency('base64', '>= 0.1', '< 0.3')
   spec.add_runtime_dependency('benchmark', '>= 0.3', '< 0.5')
   spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
   spec.add_runtime_dependency('deep_merge', '~> 1.0')

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('racc', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
+  spec.add_runtime_dependency('syslog', '>= 0.1', '< 0.3')
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'


### PR DESCRIPTION
With Ruby 3.4 the base64 gem changed from a default gem to a bundled gem. This means it needs to be specified as a dependency.