### PR TITLE
Reflect Ruby 3.4 stack trace changes

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -523,7 +523,11 @@ module Util
 
   module_function :thinmark
 
-  PUPPET_STACK_INSERTION_FRAME = /.*puppet_stack\.rb.*in.*`stack'/
+  PUPPET_STACK_INSERTION_FRAME = if RUBY_VERSION >= '3.4'
+                                   /.*puppet_stack\.rb.*in.*'Puppet::Pops::PuppetStack\.stack'/
+                                 else
+                                   /.*puppet_stack\.rb.*in.*`stack'/
+                                 end
 
   # utility method to get the current call stack and format it to a human-readable string (which some IDEs/editors
   # will recognize as links to the line numbers in the trace)

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -455,7 +455,7 @@ original
         expect(log.message).to_not match('/logging_spec.rb')
         expect(log.backtrace[0]).to match('/logging_spec.rb')
 
-        expect(log.backtrace.any? { |l| l =~ /\/tmp\/test2\.pp:20/ }).to be true
+        expect(log.backtrace).to include(/\/tmp\/test2\.pp:20/)
         puppetstack = log.backtrace.select { |l| l =~ /tmp\/test\d\.pp/ }
 
         expect(puppetstack.length).to eq(3)


### PR DESCRIPTION
Ruby 3.4 changed the stack frame formatting and that meant it no longer recognized the Puppet stack frames. This updates the regex for the new format.