### PR TITLE
GCG: move it to dedicated gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group(:development, optional: true) do
 end
 
 group(:packaging) do
-  gem 'github_changelog_generator'
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 end
 
@@ -77,6 +76,11 @@ group(:documentation, optional: true) do
   gem 'ronn-ng', '~> 0.10.1', require: false, platforms: [:ruby]
   gem 'puppet-strings', require: false, platforms: [:ruby]
   gem 'pandoc-ruby', require: false, platforms: [:ruby]
+end
+
+group :release, optional: true do
+  gem 'faraday-retry', require: false
+  gem 'github_changelog_generator', require: false
 end
 
 if File.exist? "#{__FILE__}.local"

--- a/Rakefile
+++ b/Rakefile
@@ -165,6 +165,6 @@ begin
   end
 rescue LoadError
   task :changelog do
-    abort("Run `bundle install --with packaging` to install the `github_changelog_generator` gem.")
+    abort("Run `bundle install --with release` to install the `github_changelog_generator` gem.")
   end
 end


### PR DESCRIPTION
That allows us to skip the installation. It also has dependencies that are incompatible with JRuby.