### PR TITLE
Switch to $serverimplementation

### DIFF
--- a/lib/puppet/node/server_facts.rb
+++ b/lib/puppet/node/server_facts.rb
@@ -5,7 +5,7 @@ class Puppet::Node::ServerFacts
     server_facts = {}
 
     # Add implementation information
-    server_facts["implementation"] = Puppet.implementation
+    server_facts["serverimplementation"] = Puppet.implementation
 
     # Add our server Puppet Enterprise version, if available.
     pe_version_file = '/opt/puppetlabs/server/pe_version'


### PR DESCRIPTION
This avoids the spurious warning when copying facts and server_facts to
top level. (which we NEED to deprecate.)

Fixes OpenVoxProject/openvox-agent#66
