### PR TITLE
Revert "Depend on the syslog gem"

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('racc', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
-  spec.add_runtime_dependency('syslog', '>= 0.1', '< 0.3')
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'


### PR DESCRIPTION
This reverts commit 6fcc677d728be2faa0ce68922f518d54cca16d49.

This removes the explicity syslog dependency. It's required for Ruby 3.4 support, but breaks support for JRuby.