### PR TITLE
GCG: move it to dedicated gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,13 +66,17 @@ group(:development, optional: true) do
 end
 
 group(:packaging) do
-  gem 'github_changelog_generator'
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 end
 
 group(:documentation, optional: true) do
   gem 'gettext-setup', '~> 0.28', require: false, platforms: [:ruby]
   gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
+end
+
+group :release, optional: true do
+  gem 'faraday-retry', require: false
+  gem 'github_changelog_generator', require: false
 end
 
 if File.exist? "#{__FILE__}.local"

--- a/Rakefile
+++ b/Rakefile
@@ -155,6 +155,6 @@ begin
   end
 rescue LoadError
   task :changelog do
-    abort("Run `bundle install --with packaging` to install the `github_changelog_generator` gem.")
+    abort("Run `bundle install --with release` to install the `github_changelog_generator` gem.")
   end
 end


### PR DESCRIPTION
That allows us to skip the installation. It also has dependencies that are incompatible with JRuby.

(cherry picked from commit 97e13bb1ae441ef9a18440bda84263b25e3d54f4)