### PR TITLE
CI: Run JRuby tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
-          - {os: ubuntu-latest, ruby: 'jruby-9.3.14.0'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}


### PR DESCRIPTION
The prebuilt jruby is only available for Ubuntu 22.04, not 24.04, check https://github.com/ruby/ruby-builder/releases/tag/toolcache

* jruby-9.3.14.0-macos-13-arm64.tar.gz
* jruby-9.3.14.0-macos-latest.tar.gz
* jruby-9.3.14.0-ubuntu-22.04.tar.gz
* jruby-9.3.14.0-windows-latest.tar.gz