### PR TITLE
CI: Dont abort all jobs on a single fail

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -14,6 +14,7 @@ jobs:
   rspec_tests:
     name: ${{ matrix.cfg.os }}(ruby ${{ matrix.cfg.ruby }})
     strategy:
+      fail-fast: false
       matrix:
         cfg:
           - {os: ubuntu-latest, ruby: '2.5'}


### PR DESCRIPTION
It just makes debugging multiple issues impossible