### PR TITLE
Release: Fix path to gem

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,4 +38,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} pkg/*.gem
+        run: gh release upload ${{ github.ref_name }} *.gem


### PR DESCRIPTION
The gem artifact isn't in the pkg/ subfolder, it's in the root dir.