### PR TITLE
Maintain consistent JSON formatting / Add space to URI error

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -164,7 +164,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
       case result
       when Array, Hash
-        Puppet::Util::Json.dump(result, :pretty => true)
+        # JSON < 2.8.0 would pretty print empty arrays and hashes with newlines
+        # Maintain that behavior for our users for now
+        if result.is_a?(Array) && result.empty?
+          "[\n\n]"
+        elsif result.is_a?(Hash) && result.empty?
+          "{\n}"
+        else
+          Puppet::Util::Json.dump(result, :pretty => true)
+        end
       else # one of VALID_TYPES above
         result
       end

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   spec.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
   spec.add_runtime_dependency(%q<scanf>, "~> 1.0")
+  spec.add_runtime_dependency(%q<json>, "< 2.9") # last known good version is 2.8.2
 
   # For building platform specific puppet gems...the --platform flag is only supported in newer Ruby versions
   platform = spec.platform.to_s

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -91,6 +91,7 @@ describe Puppet::Application::Facts do
 
     {
       "type_hash" => [{'a' => 2}, "{\n  \"a\": 2\n}"],
+      "type_empty_hash" => [{}, "{\n}"],
       "type_array" => [[], "[\n\n]"],
       "type_string" => ["str", "str"],
       "type_int" => [1, "1"],

--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -77,7 +77,13 @@ describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
 
       it "raises if given an invalid URI" do
         resource[:source] = 'h;ttp://rubygems.com'
-        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI\(is not URI\?\)/)
+        # Older versions of URI don't have a space before the opening
+        # parenthesis in the error message, newer versions do
+        if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('3.0.0')
+          expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI\(is not URI\?\)/)
+        else
+          expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI \(is not URI\?\)/)
+        end
       end
     end
   end


### PR DESCRIPTION
The JSON gem has historically included newlines when pretty printing empty arrays or hashes. This changed with ruby/json@b2c4480 in JSON 2.8.0.

In order to maintain consistent behavior for our users, this commit special cases empty array and hash facts and adds a new test for empty hashes.