### PR TITLE
Maintain consistent JSON formatting 

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -167,7 +167,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
       case result
       when Array, Hash
-        Puppet::Util::Json.dump(result, :pretty => true)
+        # JSON < 2.8.0 would pretty print empty arrays and hashes with newlines
+        # Maintain that behavior for our users for now
+        if result.is_a?(Array) && result.empty?
+          "[\n\n]"
+        elsif result.is_a?(Hash) && result.empty?
+          "{\n}"
+        else
+          Puppet::Util::Json.dump(result, :pretty => true)
+        end
       else # one of VALID_TYPES above
         result
       end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -91,7 +91,8 @@ describe Puppet::Application::Facts do
 
     {
       "type_hash" => [{'a' => 2}, "{\n  \"a\": 2\n}"],
-      "type_array" => [[], "[]"],
+      "type_empty_hash" => [{}, "{\n}"],
+      "type_array" => [[], "[\n\n]"],
       "type_string" => ["str", "str"],
       "type_int" => [1, "1"],
       "type_float" => [1.0, "1.0"],


### PR DESCRIPTION
The JSON gem has historically included newlines when pretty printing
empty arrays or hashes. This changed with https://github.com/ruby/json/commit/b2c4480 in JSON
2.8.0.

In order to maintain consistent behavior for our users, this commit
special cases empty array and hash facts and adds a new test for empty
hashes.


Contains https://github.com/OpenVoxProject/puppet/pull/129. Cherry-picked from https://github.com/puppetlabs/puppet/commit/295d2f9071a46d82f73947963f761471bd011d88