### PR TITLE
Fix the release action

### DIFF
--- a/tasks/vox.rake
+++ b/tasks/vox.rake
@@ -9,14 +9,14 @@ namespace :vox do
     puts "Setting version to #{version}"
 
     data = File.read('lib/puppet/version.rb')
-    new_data = data.sub(/PUPPETVERSION = '\d+\.\d+\.\d+'/, "PUPPETVERSION = '#{version}'")
-    raise 'Failed to update version in lib/puppet/version.rb' if data == new_data
+    new_data = data.sub(/PUPPETVERSION = '\d+\.\d+\.\d+(\.rc\d+)?'/, "PUPPETVERSION = '#{version}'")
+    warn 'Failed to update version in lib/puppet/version.rb' if data == new_data
 
     File.write('lib/puppet/version.rb', new_data)
 
     data = File.read('openvox.gemspec')
-    new_data = data.sub(/spec.version = "\d+\.\d+\.\d+"/, "spec.version = \"#{version}\"")
-    raise 'Failed to update version in openvox.gemspec' if data == new_data
+    new_data = data.sub(/spec.version = "\d+\.\d+\.\d+(\.rc\d+)?"/, "spec.version = \"#{version}\"")
+    warn 'Failed to update version in openvox.gemspec' if data == new_data
 
     File.write('openvox.gemspec', new_data)
   end


### PR DESCRIPTION
Make it compatible with release candidates and do not fail if a
substitution does not update a file because we use this to make sure the
version we release match what is found in the code.
