### PR TITLE
Fix FreeBSD default package provider in the test suite

### DIFF
--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
         :rug
       end
     when 'FreeBSD'
-      :ports
+      :pkgng
     when 'OpenBSD'
       :openbsd
     when 'DragonFly'


### PR DESCRIPTION
pkgng has been the default provider for FreeBSD since 5899a6a886dc411ff62a6b1feae17fabd3811d91.

The tests seems to fail only when run on FreeBSD.
