### PR TITLE
(maint) Drop debian-10 from testing matrix

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -79,7 +79,6 @@ jobs:
         os:
           - [almalinux, '8']
           - [almalinux, '9']
-          - [debian, '10']
           - [debian, '11']
           - [debian, '12']
           # No Debian 13 in 7.x


### PR DESCRIPTION
Debian 10 was eol last year. Packages have now been dropped from the main deb.debian.org mirrors and are now available only from archive.debian.org, so the images no longer work correctly.