### PR TITLE
Make passing invalid options to install.rb fatal

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -159,6 +159,9 @@ def prepare_installation
     end
 
     opts.parse!
+  rescue OptionParser::InvalidOption => e
+    $stderr.puts e
+    exit 1
   end
 
   # Mac OS X 10.5 and higher declare bindir


### PR DESCRIPTION
In b909b673bae784af7822fcd58549fd6773b4320b the --[no-]prereq-checks option was dropped. The error was printed, but then continued to execute and it ignored all passed options. That caused a regression in 8.21.0.

It now catches the error and exits with a non-zero exit code, forcing the packager to deal with it.