### PR TITLE
Allow file content that looks like a checksum.

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1055,13 +1055,6 @@ EOT
       # Sure would be nice to set the Puppet::Util::Log destination here in an :on_initialize_and_write hook,
       # unfortunately we have a large number of tests that rely on the logging not resetting itself when the
       # settings are initialized as they test what gets logged during settings initialization.
-    },
-    :use_checksum_in_file_content => {
-      :default => true,
-      :type    => :boolean,
-      :desc    => "Whether to allow specifying checksums in file content attributes; this is
-      deprecated, the checksum retrieval functionality is being replaced by the use of
-      static catalogs."
     }
   )
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1055,6 +1055,13 @@ EOT
       # Sure would be nice to set the Puppet::Util::Log destination here in an :on_initialize_and_write hook,
       # unfortunately we have a large number of tests that rely on the logging not resetting itself when the
       # settings are initialized as they test what gets logged during settings initialization.
+    },
+    :use_checksum_in_file_content => {
+      :default => true,
+      :type    => :boolean,
+      :desc    => "Whether to allow specifying checksums in file content attributes; this is
+      deprecated, the checksum retrieval functionality is being replaced by the use of
+      static catalogs."
     }
   )
 

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -54,27 +54,6 @@ module Puppet
         if @actual_content || resource.parameter(:source)
           # Actual content is already set, value contains it's checksum
           value
-        elsif Puppet[:use_checksum_in_file_content]
-          # The value passed in the "content" attribute of this file looks like
-          # a checksum, and this is intended by the user.
-          # Display a warning as this behavior is deprecated.
-          Puppet.puppet_deprecation_warning([
-            # TRANSLATORS "content" is an attribute and should not be translated
-            _('Using a checksum in a file\'s "content" property is deprecated.'),
-            # TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
-            _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
-            # TRANSLATORS "content" is an attribute and should not be translated.
-            _('The literal value of the "content" property will be written to the file.'),
-            # TRANSLATORS "static catalogs" should not be translated.
-            _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
-            _('See https://puppet.com/docs/puppet/latest/static_catalogs.html for more information.')
-          ].join(" "),
-                                            :file => @resource.file,
-                                            :line => @resource.line) if !@actual_content && !resource.parameter(:source)
-          # We return the value assuming it really is the checksum of the
-          # actual content we want. It should be fetched from filebucket
-          # later on.
-          value
         else
           # The content only happens to look like a checksum by chance.
           @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
@@ -172,17 +151,11 @@ module Puppet
     def each_chunk_from
       if actual_content.is_a?(String)
         yield actual_content
-      elsif content_is_really_a_checksum? && actual_content.nil?
+      elsif actual_content.nil?
         yield read_file_from_filebucket
       elsif actual_content.nil?
         yield ''
       end
-    end
-
-    def content_is_really_a_checksum?
-      return false unless Puppet[:use_checksum_in_file_content]
-
-      checksum?(should)
     end
 
     def read_file_from_filebucket

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -48,23 +48,43 @@ module Puppet
       if value == :absent
         value
       elsif value.is_a?(String) && checksum?(value)
-        # XXX This is potentially dangerous because it means users can't write a file whose
-        # entire contents are a plain checksum unless it is a Binary content.
-        Puppet.puppet_deprecation_warning([
-          # TRANSLATORS "content" is an attribute and should not be translated
-          _('Using a checksum in a file\'s "content" property is deprecated.'),
-          # TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
-          _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
-          # TRANSLATORS "content" is an attribute and should not be translated.
-          _('The literal value of the "content" property will be written to the file.'),
-          # TRANSLATORS "static catalogs" should not be translated.
-          _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
-          _('See https://docs.openvoxproject.org/openvox/latest/static_catalogs.html for more information.')
-        ].join(" "),
-                                          :file => @resource.file,
-                                          :line => @resource.line) if !@actual_content && !resource.parameter(:source)
-        value
+        # Our argument looks like a checksum. Is it the value of the content
+        # attribute in Puppet code, that happens to look like a checksum, or is
+        # it an actual checksum computed on the actual content?
+        if @actual_content || resource.parameter(:source)
+          # Actual content is already set, value contains it's checksum
+          value
+        else
+          # The value passed in the "content" attribute of this file looks like a checksum.
+          if Puppet[:use_checksum_in_file_content]
+            # Assume user wants the deprecated behavior; display a warning though.
+            # XXX This is potentially dangerous because it means users can't write a file whose
+            # entire contents are a plain checksum unless it is a Binary content.
+            Puppet.puppet_deprecation_warning([
+              # TRANSLATORS "content" is an attribute and should not be translated
+              _('Using a checksum in a file\'s "content" property is deprecated.'),
+              # TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
+              _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
+              # TRANSLATORS "content" is an attribute and should not be translated.
+              _('The literal value of the "content" property will be written to the file.'),
+              # TRANSLATORS "static catalogs" should not be translated.
+              _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
+              _('See https://docs.openvoxproject.org/openvox/latest/static_catalogs.html for more information.')
+            ].join(" "),
+                                              :file => @resource.file,
+                                              :line => @resource.line) if !@actual_content && !resource.parameter(:source)
+            # We return the value assuming it really is the checksum of the
+            # actual content we want. It should be fetched from filebucket
+            # later on.
+            value
+          else
+            # The content only happens to look like a checksum by chance.
+            @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
+            resource.parameter(:checksum).sum(@actual_content)
+          end
+        end
       else
+        # Our argument is definitely not a checksum: set actual_value and return calculated checksum.
         @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
         resource.parameter(:checksum).sum(@actual_content)
       end
@@ -163,6 +183,8 @@ module Puppet
     end
 
     def content_is_really_a_checksum?
+      return false unless Puppet[:use_checksum_in_file_content]
+
       checksum?(should)
     end
 

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -47,20 +47,14 @@ module Puppet
     munge do |value|
       if value == :absent
         value
-      elsif value.is_a?(String) && checksum?(value)
-        # Our argument looks like a checksum. Is it the value of the content
-        # attribute in Puppet code, that happens to look like a checksum, or is
-        # it an actual checksum computed on the actual content?
-        if @actual_content || resource.parameter(:source)
-          # Actual content is already set, value contains it's checksum
-          value
-        else
-          # The content only happens to look like a checksum by chance.
-          @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
-          resource.parameter(:checksum).sum(@actual_content)
-        end
+      elsif value.is_a?(String) && checksum?(value) && (@actual_content || resource.parameter(:source))
+        # The actual content is already known, either because it was
+        # previously set or because it comes from a source, and the value is
+        # its checksum.
+        value
       else
-        # Our argument is definitely not a checksum: set actual_value and return calculated checksum.
+        # The value is the desired file content, even if it happens to look
+        # like a checksum.
         @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
         resource.parameter(:checksum).sum(@actual_content)
       end
@@ -146,27 +140,14 @@ module Puppet
 
     private
 
-    # the content is munged so if it's a checksum source_or_content is nil
-    # unless the checksum indirectly comes from source
+    # actual_content is only nil when the munged value is a checksum of
+    # content that comes from a source
     def each_chunk_from
       if actual_content.is_a?(String)
         yield actual_content
       elsif actual_content.nil?
-        yield read_file_from_filebucket
-      elsif actual_content.nil?
         yield ''
       end
-    end
-
-    def read_file_from_filebucket
-      dipper = resource.bucket
-      raise "Could not get filebucket from file" unless dipper
-
-      sum = should.sub(/\{\w+\}/, '')
-
-      dipper.getfile(sum)
-    rescue => detail
-      self.fail Puppet::Error, "Could not retrieve content for #{should} from filebucket: #{detail}", detail
     end
   end
 end

--- a/lib/puppet/type/file/content.rb
+++ b/lib/puppet/type/file/content.rb
@@ -54,34 +54,31 @@ module Puppet
         if @actual_content || resource.parameter(:source)
           # Actual content is already set, value contains it's checksum
           value
+        elsif Puppet[:use_checksum_in_file_content]
+          # The value passed in the "content" attribute of this file looks like
+          # a checksum, and this is intended by the user.
+          # Display a warning as this behavior is deprecated.
+          Puppet.puppet_deprecation_warning([
+            # TRANSLATORS "content" is an attribute and should not be translated
+            _('Using a checksum in a file\'s "content" property is deprecated.'),
+            # TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
+            _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
+            # TRANSLATORS "content" is an attribute and should not be translated.
+            _('The literal value of the "content" property will be written to the file.'),
+            # TRANSLATORS "static catalogs" should not be translated.
+            _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
+            _('See https://puppet.com/docs/puppet/latest/static_catalogs.html for more information.')
+          ].join(" "),
+                                            :file => @resource.file,
+                                            :line => @resource.line) if !@actual_content && !resource.parameter(:source)
+          # We return the value assuming it really is the checksum of the
+          # actual content we want. It should be fetched from filebucket
+          # later on.
+          value
         else
-          # The value passed in the "content" attribute of this file looks like a checksum.
-          if Puppet[:use_checksum_in_file_content]
-            # Assume user wants the deprecated behavior; display a warning though.
-            # XXX This is potentially dangerous because it means users can't write a file whose
-            # entire contents are a plain checksum unless it is a Binary content.
-            Puppet.puppet_deprecation_warning([
-              # TRANSLATORS "content" is an attribute and should not be translated
-              _('Using a checksum in a file\'s "content" property is deprecated.'),
-              # TRANSLATORS "filebucket" is a resource type and should not be translated. The quoted occurrence of "content" is an attribute and should not be translated.
-              _('The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release.'),
-              # TRANSLATORS "content" is an attribute and should not be translated.
-              _('The literal value of the "content" property will be written to the file.'),
-              # TRANSLATORS "static catalogs" should not be translated.
-              _('The checksum retrieval functionality is being replaced by the use of static catalogs.'),
-              _('See https://docs.openvoxproject.org/openvox/latest/static_catalogs.html for more information.')
-            ].join(" "),
-                                              :file => @resource.file,
-                                              :line => @resource.line) if !@actual_content && !resource.parameter(:source)
-            # We return the value assuming it really is the checksum of the
-            # actual content we want. It should be fetched from filebucket
-            # later on.
-            value
-          else
-            # The content only happens to look like a checksum by chance.
-            @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
-            resource.parameter(:checksum).sum(@actual_content)
-          end
+          # The content only happens to look like a checksum by chance.
+          @actual_content = value.is_a?(Puppet::Pops::Types::PBinaryType::Binary) ? value.binary_buffer : value
+          resource.parameter(:checksum).sum(@actual_content)
         end
       else
         # Our argument is definitely not a checksum: set actual_value and return calculated checksum.

--- a/references/configuration.md
+++ b/references/configuration.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-built_from_commit: 37d76465f12159a7ef5b81447871c22f00f8a185
+built_from_commit: ac49e313d52da074fb7ff445c3e5021597940e53
 title: Configuration Reference
 toc: columns
 canonical: "/openvox/latest/configuration.html"
@@ -8,7 +8,7 @@ canonical: "/openvox/latest/configuration.html"
 
 # Configuration Reference
 
-> **NOTE:** This page was generated from the OpenVox source code on 2026-08-03 08:24:32 -0500
+> **NOTE:** This page was generated from the OpenVox source code on 2026-08-03 08:25:19 -0500
 
 
 
@@ -2097,14 +2097,6 @@ does not contact the primary server for a new catalog, it also does not upload f
 the beginning of the OpenVox run.
 
 - *Default*: `false`
-
-### use_checksum_in_file_content
-
-Whether to allow specifying checksums in file content attributes; this is
-deprecated, the checksum retrieval functionality is being replaced by the use of
-static catalogs.
-
-- *Default*: `true`
 
 ### use_last_environment
 

--- a/references/configuration.md
+++ b/references/configuration.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-built_from_commit: 3d665fe7a4a7dfa794748a310db79025a4d932cc
+built_from_commit: 37d76465f12159a7ef5b81447871c22f00f8a185
 title: Configuration Reference
 toc: columns
 canonical: "/openvox/latest/configuration.html"
@@ -8,7 +8,7 @@ canonical: "/openvox/latest/configuration.html"
 
 # Configuration Reference
 
-> **NOTE:** This page was generated from the OpenVox source code on 2026-08-01 22:12:47 +0000
+> **NOTE:** This page was generated from the OpenVox source code on 2026-08-03 08:24:32 -0500
 
 
 
@@ -2097,6 +2097,14 @@ does not contact the primary server for a new catalog, it also does not upload f
 the beginning of the OpenVox run.
 
 - *Default*: `false`
+
+### use_checksum_in_file_content
+
+Whether to allow specifying checksums in file content attributes; this is
+deprecated, the checksum retrieval functionality is being replaced by the use of
+static catalogs.
+
+- *Default*: `true`
 
 ### use_last_environment
 

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -636,6 +636,15 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       catalog.apply
     end
 
+    it "should not give a deprecation warning when checksum are disabled in content" do
+      Puppet[:use_checksum_in_file_content] = false
+      expect(Puppet).not_to receive(:puppet_deprecation_warning)
+      file = described_class.new(:path => path, :content => '{ABCD}X')
+      catalog.add_resource file
+      catalog.apply
+      expect(File.read(file[:path])).to eq('{ABCD}X')
+    end
+
     with_digest_algorithms do
       it_should_behave_like "files are backed up", {} do
         let(:filebucket_digest) { method(:digest) }

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -636,15 +636,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       catalog.apply
     end
 
-    it "should not give a deprecation warning when checksum are disabled in content" do
-      Puppet[:use_checksum_in_file_content] = false
-      expect(Puppet).not_to receive(:puppet_deprecation_warning)
-      file = described_class.new(:path => path, :content => '{ABCD}X')
-      catalog.add_resource file
-      catalog.apply
-      expect(File.read(file[:path])).to eq('{ABCD}X')
-    end
-
     with_digest_algorithms do
       it_should_behave_like "files are backed up", {} do
         let(:filebucket_digest) { method(:digest) }

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -640,20 +640,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       it_should_behave_like "files are backed up", {} do
         let(:filebucket_digest) { method(:digest) }
       end
-
-      it "should give a checksum deprecation warning" do
-        expect(Puppet).to receive(:puppet_deprecation_warning).with('Using a checksum in a file\'s "content" property is deprecated. The ability to use a checksum to retrieve content from the filebucket using the "content" property will be removed in a future release. The literal value of the "content" property will be written to the file. The checksum retrieval functionality is being replaced by the use of static catalogs. See https://docs.openvoxproject.org/openvox/latest/static_catalogs.html for more information.', {:file => 'my/file.pp', :line => 5})
-        d = digest("this is some content")
-        catalog.add_resource described_class.new(:path => path, :content => "{#{digest_algorithm}}#{d}")
-        catalog.apply
-      end
-
-      it "should not give a checksum deprecation warning when no content is specified while checksum and checksum value are used" do
-        expect(Puppet).not_to receive(:puppet_deprecation_warning)
-        d = digest("this is some content")
-        catalog.add_resource described_class.new(:path => path, :checksum => digest_algorithm, :checksum_value => d)
-        catalog.apply
-      end
     end
 
     CHECKSUM_TYPES_TO_TRY.each do |checksum_type, checksum|

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -630,15 +630,24 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
       end
     end
 
-    it "should not give a checksum deprecation warning when given actual content" do
-      expect(Puppet).not_to receive(:puppet_deprecation_warning)
-      catalog.add_resource described_class.new(:path => path, :content => 'this is content')
+    it "should write content that looks like a checksum literally" do
+      file = described_class.new(:path => path, :content => '{ABCD}X')
+      catalog.add_resource file
       catalog.apply
+      expect(File.read(path)).to eq('{ABCD}X')
     end
 
     with_digest_algorithms do
       it_should_behave_like "files are backed up", {} do
         let(:filebucket_digest) { method(:digest) }
+      end
+
+      it "should write content that is a valid checksum literally" do
+        d = digest("this is some content")
+        file = described_class.new(:path => path, :content => "{#{digest_algorithm}}#{d}")
+        catalog.add_resource file
+        catalog.apply
+        expect(File.read(path)).to eq("{#{digest_algorithm}}#{d}")
       end
     end
 

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -37,11 +37,6 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
   describe "when setting the desired content" do
     let(:content) { described_class.new(:resource => resource) }
 
-    before do
-      allow_any_instance_of(Puppet::Type.type(:file)).to receive(:file).and_return('my/file.pp')
-      allow_any_instance_of(Puppet::Type.type(:file)).to receive(:line).and_return(5)
-    end
-
     it "should make the actual content available via an attribute" do
       content.should = "this is some content"
 
@@ -63,12 +58,24 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
         expect(content.should).to eq(:absent)
       end
 
-      it "should accept a checksum as the desired content" do
+      it "should treat a checksum as literal content when no source is set" do
         d = digest("this is some content")
 
         string = "{#{digest_algorithm}}#{d}"
         content.should = string
 
+        expect(content.actual_content).to eq(string)
+        expect(content.should).to eq("{#{digest_algorithm}}#{digest(string)}")
+      end
+
+      it "should accept a checksum as the desired content when a source is set" do
+        resource[:source] = make_absolute('/foo/bar')
+        d = digest("this is some content")
+
+        string = "{#{digest_algorithm}}#{d}"
+        content.should = string
+
+        expect(content.actual_content).to be_nil
         expect(content.should).to eq(string)
       end
     end
@@ -381,16 +388,11 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
 
     let(:fh) { File.open(filename, 'wb') }
 
-    before do
-      allow_any_instance_of(Puppet::Type.type(:file)).to receive(:file).and_return('my/file.pp')
-      allow_any_instance_of(Puppet::Type.type(:file)).to receive(:line).and_return(5)
-    end
-
-    it "should attempt to read from the filebucket if no actual content nor source exists" do
+    it "should write content that looks like a checksum literally" do
       content.should = "{md5}foo"
-      allow_any_instance_of(content.resource.bucket.class).to receive(:getfile).and_return("foo")
       content.write(fh)
       fh.close
+      expect(File.read(filename)).to eq("{md5}foo")
     end
 
     describe "from actual content" do
@@ -407,33 +409,6 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
       it "should return the current checksum value" do
         expect(resource.parameter(:checksum)).to receive(:sum_stream).and_return("checksum")
         expect(content.write(fh)).to eq("checksum")
-      end
-    end
-
-    describe "from a file bucket" do
-      it "should fail if a file bucket cannot be retrieved" do
-        content.should = "{md5}foo"
-        expect(content.resource).to receive(:bucket).and_return(nil)
-        expect { content.write(fh) }.to raise_error(Puppet::Error)
-      end
-
-      it "should fail if the file bucket cannot find any content" do
-        content.should = "{md5}foo"
-        bucket = double('bucket')
-        expect(content.resource).to receive(:bucket).and_return(bucket)
-        expect(bucket).to receive(:getfile).with("foo").and_raise("foobar")
-        expect { content.write(fh) }.to raise_error(Puppet::Error)
-      end
-
-      it "should write the returned content to the file" do
-        content.should = "{md5}foo"
-        bucket = double('bucket')
-        expect(content.resource).to receive(:bucket).and_return(bucket)
-        expect(bucket).to receive(:getfile).with("foo").and_return("mycontent")
-
-        fh = double('filehandle')
-        expect(fh).to receive(:print).with("mycontent")
-        content.write(fh)
       end
     end
   end

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -259,6 +259,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         end
 
         it "should copy the metadata's owner, group, checksum, checksum_type, and mode to the resource if they are not set on the resource" do
+          @resource[:source] = @foobar
           @source.copy_source_values
 
           expect(@resource[:owner]).to eq(100)

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -259,7 +259,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
         end
 
         it "should copy the metadata's owner, group, checksum, checksum_type, and mode to the resource if they are not set on the resource" do
-          @resource[:source] = @foobar
+          @resource[:source] = @foobar_uri
           @source.copy_source_values
 
           expect(@resource[:owner]).to eq(100)


### PR DESCRIPTION
_This pull request is intended to fix #169 . Also this is my first pull request on github._

Currently, if a file has a content attribute set to something that looks like a checksum, it will display a deprecation warning and then probably throw an error, as the checksum-like string won't match anything in filebuckets.

This code is apparently intended to allow a checksum to be passed instead of actual content, with the effect of replacing file content if it doesn't match the checksum. It appears that this mecanism is replaced by "static catalogs" and was scheduled for removal in Puppet 7.

As it is no longer documented (because deprecated), it is surprising to stumble upon the behavior by just having file content that looks like a checksum. I had to work around this in a real usecase involving some proprietary software that uses the same syntax for values to be encrypted at startup.

This commit introduces a new setting "use_checksum_in_file_content" that default to true, preserving current behavior. If set to false, it will never look for checksums in file contents.

This setting should probably be set to false by default in the next major release.