### PR TITLE
Fix how we find the version library

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -3,7 +3,7 @@
 # When we are building the gem from source, we instead look relative to where this gemspec
 # file lives. This is a little jank, but prevents us from having to update the version in
 # two different places.
-installed_path = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/version'
+installed_path = "#{__dir__}/../../../vendor_ruby/puppet/version"
 version_path = File.exist?("#{installed_path}.rb") ? installed_path : 'lib/puppet/version'
 require_relative "#{version_path}"
 


### PR DESCRIPTION
Rather than providing the absolute path to the library when installed, this uses the relative path so that we don't need to have different versions for Linux and Windows.