### PR TITLE
Promote puppet-runtime 2025.09.08.1

### DIFF
--- a/packaging/configs/components/puppet-runtime.json
+++ b/packaging/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/2025.09.04.1/","version":"2025.09.04.1"}
+{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/2025.09.08.1/","version":"2025.09.08.1"}


### PR DESCRIPTION
This reverts fast_gettext to 2.4.0 to avoid problems with r10k