### PR TITLE
More secure default server setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -863,7 +863,7 @@ names.
 **Note:** The list of alternate names is locked in when the server's
 certificate is signed. If you need to change the list later, you can't just
 change this setting; you also need to regenerate the certificate. For more
-information on that process, see the 
+information on that process, see the
 [cert regen docs](https://puppet.com/docs/puppet/latest/ssl_regenerate_certificates.html).
 
 To see all the alternate names your servers are using, log into your CA server
@@ -1650,7 +1650,7 @@ EOT
       :desc     => "The root directory of devices' $confdir.",
     },
     :server => {
-      :default => "puppet",
+      :default => Puppet.features.root? ? 'puppet' : '', # use an empty string so dependent settings can resolve without crashing
       :desc => "The primary Puppet server to which the Puppet agent should connect. This setting is ignored when `server_list` is specified.",
     },
     :server_list => {

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -147,6 +147,7 @@ describe 'lookup' do
     end
 
     it 'loads trusted information from the node certificate' do
+      Puppet.settings[:server] = 'puppet'
       Puppet.settings[:node_terminus] = 'exec'
       expect_any_instance_of(Puppet::Node::Exec).to receive(:find) do |args|
         info = Puppet.lookup(:trusted_information)

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -56,6 +56,7 @@ describe 'lookup' do
       stub_request(:get, "https://puppet:8140/puppet-ca/v1/certificate/#{fqdn}").to_return(body: cert)
       allow(Puppet::Node::Facts.indirection).to receive(:find).and_return(facts)
 
+      Puppet[:server] = 'puppet'
       Puppet[:environment] = env_name
       Puppet[:environmentpath] = populated_env_dir
 

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -135,6 +135,7 @@ describe Puppet::Configurer do
         end
 
         it 'logs errors that occur during fact submission' do
+          Puppet[:server] = 'puppet'
           stub_request(:put, "https://puppet:8140/puppet/v3/facts/configurer.test?environment=production").to_return(status: 502)
           expect(Puppet).to receive(:log_exception).with(Puppet::HTTP::ResponseError,
                                                          /^Failed to submit facts/)

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -106,6 +106,7 @@ describe Puppet::Configurer do
 
         before(:each) do
           Puppet[:resubmit_facts] = true
+          Puppet[:server] = 'puppet'
 
           allow(@configurer).to receive(:find_facts).and_return(test_facts)
         end

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -41,6 +41,7 @@ describe Puppet::Application::Filebucket do
 
   describe "during setup" do
     before :each do
+      Puppet[:server] = 'puppet'
       allow(Puppet::Log).to receive(:newdestination)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
@@ -157,6 +158,7 @@ describe Puppet::Application::Filebucket do
 
   describe "when running" do
     before :each do
+      Puppet[:server] = 'puppet'
       allow(Puppet::Log).to receive(:newdestination)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
@@ -177,6 +179,7 @@ describe Puppet::Application::Filebucket do
 
     describe "the command get" do
       before :each do
+        Puppet[:server] = 'puppet'
         allow(@filebucket).to receive(:print)
         allow(@filebucket).to receive(:args).and_return([])
       end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -23,6 +23,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
 
   before do
     Puppet.settings.use(:main)
+    Puppet.settings[:server] = 'puppet'
     Puppet[:certname] = name
     Puppet[:vardir] = tmpdir("ssl_testing")
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -8,6 +8,31 @@ describe "Defaults" do
     end
   end
 
+  describe 'server' do
+    it 'should default to `puppet` when root' do
+      allow(Puppet.features).to receive(:root?).and_return(true)
+      foo = Puppet::Settings.new
+      Puppet.initialize_default_settings!(foo)
+      expect(foo[:server]).to eq('puppet')
+    end
+
+    it 'should default to empty value when non-root' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      foo = Puppet::Settings.new
+      Puppet.initialize_default_settings!(foo)
+      expect(foo[:server]).to eq('')
+    end
+
+    it 'should fail when trying to establish a compiler connection without setting `server`' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      expect {
+        client = Puppet.runtime[:http]
+        session = client.create_session
+        service = session.route_to(:puppet)
+      }.to raise_exception ArgumentError, /Required setting/
+    end
+  end
+
   describe 'strict' do
     it 'should accept the valid value :off' do
       expect {Puppet.settings[:strict] = 'off'}.to_not raise_exception


### PR DESCRIPTION
Under some fairly obscure conditions, defaulting the server setting to
'puppet' can be a security concern. Because the worst case scenario
involves a user accidentally running `puppet agent -t` on an untrusted
network, this PR removes the default completely when non-root.
Otherwise, it just prints a deprecation warning.

Fixes https://github.com/voxpupuli/security-tracking/issues/22
