### PR TITLE
Use native compilation for macos-all-x86_64

### DIFF
--- a/packaging/configs/components/pl-ruby-patch.rb
+++ b/packaging/configs/components/pl-ruby-patch.rb
@@ -8,11 +8,6 @@
 # This component should also be present in the puppet-runtime project
 component "pl-ruby-patch" do |pkg, settings, platform|
   if platform.is_cross_compiled?
-    if platform.is_macos?
-      pkg.build_requires 'gnu-sed'
-      pkg.environment "PATH", "/usr/local/opt/gnu-sed/libexec/gnubin:$(PATH)"
-    end
-
     ruby_api_version = settings[:ruby_version].gsub(/\.\d*$/, '.0')
     ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
 
@@ -26,8 +21,6 @@ component "pl-ruby-patch" do |pkg, settings, platform|
                       "powerpc64le-linux"
                     elsif platform.name == 'solaris-11-sparc'
                       "sparc-solaris-2.11"
-                    elsif platform.is_macos?
-                      "aarch64-darwin"
                     else
                       "#{platform.architecture}-linux"
                     end

--- a/packaging/configs/components/puppet-runtime.rb
+++ b/packaging/configs/components/puppet-runtime.rb
@@ -21,9 +21,6 @@ component 'puppet-runtime' do |pkg, settings, platform|
       pkg.build_requires 'pl-ruby'
     elsif platform.is_linux?
       pkg.build_requires 'pl-ruby'
-    elsif platform.is_macos?
-      ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-      pkg.build_requires "ruby@#{ruby_version_y}"
     end
   end
 

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -11,10 +11,6 @@ namespace :vox do
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
     os, _ver, arch = platform.match(/^(\w+)-([\w|\.]+)-(\w+)$/).captures
-    if os == 'macos'
-      abort "You must run this build from a #{arch} machine or shell. To do this on the current host, run 'arch -#{arch} /bin/bash'" if `uname -m`.chomp != arch
-      abort "You must run this build with a #{arch} Ruby version. To do this on the current host, install Ruby from an #{arch} shell via 'arch -#{arch} /bin/bash'." unless `ruby -v`.chomp =~ /#{arch}/
-    end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"


### PR DESCRIPTION
The experiment to use Rosetta on an arm64 host to build macos-all-x86_64 didn't quite work out, so we're going to build on native x86_64 hosts instead.