### PR TITLE
Use cross-compilation for macos-all-x86_64

### DIFF
--- a/packaging/configs/components/pl-ruby-patch.rb
+++ b/packaging/configs/components/pl-ruby-patch.rb
@@ -10,14 +10,14 @@ component "pl-ruby-patch" do |pkg, settings, platform|
   if platform.is_cross_compiled?
     if platform.is_macos?
       pkg.build_requires 'gnu-sed'
-      pkg.environment "PATH", "/usr/local/opt/gnu-sed/libexec/gnubin:$(PATH)"
+      pkg.environment "PATH", "/opt/homebrew/opt/gnu-sed/libexec/gnubin:$(PATH)"
     end
 
     ruby_api_version = settings[:ruby_version].gsub(/\.\d*$/, '.0')
     ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
 
     base_ruby = if platform.name =~ /macos/
-                  "/usr/local/opt/ruby@#{ruby_version_y}/lib/ruby/#{ruby_api_version}"
+                  "/opt/homebrew/opt/ruby@#{ruby_version_y}/lib/ruby/#{ruby_version_y}.0"
                 else
                   "/opt/pl-build-tools/lib/ruby/2.1.0"
                 end
@@ -27,7 +27,7 @@ component "pl-ruby-patch" do |pkg, settings, platform|
                     elsif platform.name == 'solaris-11-sparc'
                       "sparc-solaris-2.11"
                     elsif platform.is_macos?
-                      "aarch64-darwin"
+                      "x86_64-darwin"
                     else
                       "#{platform.architecture}-linux"
                     end

--- a/packaging/configs/components/puppet.rb
+++ b/packaging/configs/components/puppet.rb
@@ -85,10 +85,7 @@ component "puppet" do |pkg, settings, platform|
     if platform.is_windows?
       msgfmt = "/usr/bin/msgfmt.exe"
     elsif platform.is_macos?
-      msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
-      if platform.architecture == 'arm64'
-        msgfmt = "/opt/homebrew/bin/msgfmt"
-      end
+      msgfmt = "/opt/homebrew/bin/msgfmt"
     else
       msgfmt = "msgfmt"
     end

--- a/packaging/configs/platforms/macos-all-x86_64.rb
+++ b/packaging/configs/platforms/macos-all-x86_64.rb
@@ -1,4 +1,6 @@
 platform 'macos-all-x86_64' do |plat|
   plat.inherit_from_default
+  plat.brew '/opt/homebrew/bin/brew'
+  plat.cross_compiled true
   plat.output_dir File.join('macos', 'all', 'x86_64')
 end

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -11,10 +11,6 @@ namespace :vox do
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
     os, _ver, arch = platform.match(/^(\w+)-([\w|\.]+)-(\w+)$/).captures
-    if os == 'macos'
-      abort "You must run this build from a #{arch} machine or shell. To do this on the current host, run 'arch -#{arch} /bin/bash'" if `uname -m`.chomp != arch
-      abort "You must run this build with a #{arch} Ruby version. To do this on the current host, install Ruby from an #{arch} shell via 'arch -#{arch} /bin/bash'." unless `ruby -v`.chomp =~ /#{arch}/
-    end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"


### PR DESCRIPTION
Now that we have cross-compilation working, remove the changes made when we were using Rosetta.