### PR TITLE
Introduce the Linux runmode

### DIFF
--- a/lib/puppet/util/platform.rb
+++ b/lib/puppet/util/platform.rb
@@ -21,6 +21,11 @@ module Puppet
       end
       module_function :solaris?
 
+      def linux?
+        RUBY_PLATFORM.include?('linux')
+      end
+      module_function :linux?
+
       def default_paths
         return [] if windows?
 

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -160,5 +160,85 @@ module Puppet
         [ENV.fetch('ALLUSERSPROFILE', nil), "PuppetLabs"] + extra
       end
     end
+
+    # A Linux runmode, using systemd, FHS and XDG standards
+    #
+    # This first attempts systemd environment variables. If those don't exist
+    # it falls back to using hardcoded directories for root and XDG directories
+    # for non-root users. XDG describes various environment variables with
+    # recommended fallbacks.
+    #
+    # @see https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
+    # @see https://specifications.freedesktop.org/basedir-spec/latest/
+    class LinuxRunMode < RunMode
+      def conf_dir
+        ENV.fetch('CONFIGURATION_DIRECTORY') do
+          config_home = which_dir("/etc", ENV.fetch("XDG_CONFIG_HOME", "~/.config"))
+          File.join(config_home, packaging_name)
+        end
+      end
+
+      def code_dir
+        File.join(conf_dir, 'code')
+      end
+
+      def var_dir
+        ENV.fetch('STATE_DIRECTORY') do
+          data_home = which_dir("/var/lib", ENV.fetch("XDG_DATA_HOME", "~/.local/share"))
+          File.join(data_home, packaging_name)
+        end
+      end
+
+      def cache_directory
+        ENV.fetch('CACHE_DIRECTORY') do
+          cache_home = which_dir("/var/cache", ENV.fetch("XDG_CACHE_HOME", "~/.cache"))
+          File.join(cache_home, packaging_name)
+        end
+      end
+
+      def public_dir
+        File.join(cache_directory, 'public')
+      end
+
+      def run_dir
+        ENV.fetch('RUNTIME_DIRECTORY') do
+          runtime_dir = which_dir("/run", ENV.fetch("XDG_RUNTIME_DIR") { File.join('/run', 'user', ::Etc.getpwuid.uid) })
+          File.join(runtime_dir, packaging_name)
+        end
+      end
+
+      def log_dir
+        ENV.fetch('LOGS_DIRECTORY') do
+          which_dir(File.join('/var', 'log', packaging_name),
+                    File.join(ENV.fetch("XDG_STATE_HOME", "~/.local/state"), packaging_name, "logs"))
+        end
+      end
+
+      def pkg_config_path
+        # automatically picked up
+      end
+
+      def gem_cmd
+        '/usr/bin/gem'
+      end
+
+      def data_dir
+        File.join('/usr', 'share', packaging_name)
+      end
+
+      def common_module_dir
+        File.join(data_dir, 'modules')
+      end
+
+      def vendor_module_dir
+        File.join(data_dir, 'vendor_modules')
+      end
+
+      private
+
+      def packaging_name
+        'puppet'
+      end
+    end
   end
 end

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -15,6 +15,8 @@ module Puppet
         @run_modes ||= {}
         if Puppet::Util::Platform.windows?
           @run_modes[name] ||= WindowsRunMode.new(name)
+        elsif Puppet::Util::Platform.linux?
+          @run_modes[name] ||= LinuxRunMode.new(name)
         else
           @run_modes[name] ||= UnixRunMode.new(name)
         end


### PR DESCRIPTION
This builds on the previous work to define all paths in the RunMode class and has a few interesting aspects.

The parts that make it Linux specific is that it prefers [systemd environment variables](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=) to determine locations. When those aren't available, it instead uses hardcoded paths for root and follows the [XDG specification](https://specifications.freedesktop.org/basedir-spec/latest/) for non-root.

This is a draft because it's more of a proposal. It has some implications that may or may not be good. For example, is it a good thing for all of them to be changeable through env vars? It can change the behavior on whether it's a service or a CLI tool.

It's porting over the work I started in https://github.com/puppetlabs/puppet/pull/8636. It's simpler because I no longer rely on `install.rb` in Fedora's packaging that I'm working on.