### PR TITLE
Allow multivalue parameters to be deferred lazily

### DIFF
--- a/lib/puppet/property.rb
+++ b/lib/puppet/property.rb
@@ -526,7 +526,7 @@ class Puppet::Property < Puppet::Parameter
 
     devfail "should for #{self.class.name} on #{resource.name} is not an array" unless @should.is_a?(Array)
 
-    if match_all?
+    if match_all? and ! (@should.one? and @should.first.instance_of? Puppet::Pops::Evaluator::DeferredValue)
       @should.collect { |val| unmunge(val) }
     else
       unmunge(@should[0])


### PR DESCRIPTION
Before this change, values returned from a deferred function would be
wrapped inside an array when resolved lazily (with the default setting
`preprocess_deferred=false`.) The resolution functions didn't detect
this and the value was not resolved before the resource was enforced.

That error case  didn't occur when preprocessing, which just enumerated
all values and resolved them before entering the enforcement lifecycle.

This change just avoids wrapping in an extra array. It expects the
function itself to return an array and will fail with an appropriate
error during catalog enforcement if it does not.

Error example:
```
Notice: Compiled catalog for waffles.localdomain in environment production in 0.01 seconds
Error: Failed to apply catalog: value returned from function 'expand_groups' has wrong type, expects an Array value, got Integer
```

Fixes #213
