### PR TITLE
include "local" facts in facts output

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -49,7 +49,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
                Puppet::Node::Facts.new(request.key, facts.to_h)
              end
 
-    result.add_local_facts unless request.options[:resolve_options]
+    result.add_local_facts(request.options[:user_query])
     result.sanitize
     result
   end

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -27,11 +27,12 @@ class Puppet::Node::Facts
 
   attr_accessor :name, :values, :timestamp
 
-  def add_local_facts
-    values["implementation"] = Puppet.implementation
-    values["clientcert"] = Puppet.settings[:certname]
-    values["clientversion"] = Puppet.version.to_s
-    values["clientnoop"] = Puppet.settings[:noop]
+  def add_local_facts(query = [])
+    query = Array(query) # some use cases result in a nil being passed in
+    values["implementation"] = Puppet.implementation if query.empty? or query.include? 'implementation'
+    values["clientcert"] = Puppet.settings[:certname] if query.empty? or query.include? 'clientcert'
+    values["clientversion"] = Puppet.version.to_s if query.empty? or query.include? 'clientversion'
+    values["clientnoop"] = Puppet.settings[:noop] if query.empty? or query.include? 'clientnoop'
   end
 
   def initialize(name, values = {})

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -55,7 +55,11 @@ describe Puppet::Application::Facts do
     let(:expected) { <<~END }
       {
         "filesystems": "apfs,autofs,devfs",
-        "macaddress": "64:52:11:22:03:2e"
+        "macaddress": "64:52:11:22:03:2e",
+        "implementation": "#{Puppet.implementation}",
+        "clientcert": "#{Puppet.settings[:certname]}",
+        "clientversion": "#{Puppet.version}",
+        "clientnoop": false
       }
     END
 
@@ -81,7 +85,7 @@ describe Puppet::Application::Facts do
     end
 
     it "warns and ignores value-only when multiple fact names are specified" do
-      app.command_line.args << 'filesystems' << 'macaddress' << '--value-only'
+      app.command_line.args << 'filesystems' << 'macaddress' << 'implementation' << 'clientcert' << 'clientversion' << 'clientnoop' << '--value-only'
       expect {
         app.run
       }.to exit_with(0)
@@ -121,6 +125,10 @@ describe Puppet::Application::Facts do
       ---
       filesystems: apfs,autofs,devfs
       macaddress: 64:52:11:22:03:2e
+      implementation: #{Puppet.implementation}
+      clientcert: #{Puppet.settings[:certname]}
+      clientversion: #{Puppet.version}
+      clientnoop: false
     END
 
     before :each do

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -192,12 +192,6 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    it 'should NOT add local facts' do
-      expect(facts).not_to receive(:add_local_facts)
-
-      @facter.find(@request)
-    end
-
     context 'when --show-legacy flag is present' do
       let(:options) { { resolve_options: true, user_query: ["os", "timezone"], show_legacy: true } }
 


### PR DESCRIPTION
Some years ago [a bug was filed](https://puppet.atlassian.net/browse/PUP-10717)
noting that `puppet facts show` appended all local facts when called with
one or more specific facts. This was resolved by simply not including
local facts for this specific subcommand.

This had the unfortunate side effect that something like `puppet facts
show clientcert` no longer displayed anything. (note: you could still
run `puppet config print certname` but that takes a LOT of institutional
knowledge to know that those are the same thing.) Worse, when we added
the `implementation` local fact, it also didn't display.

This PR just returns to including the local facts into `puppet fact show`
output, but only the ones requested or when requesting all facts.

Fixes #220
