### PR TITLE
Fix description of `source` since `yum` allows it now

### DIFF
--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -426,7 +426,7 @@ module Puppet
     newparam(:source) do
       desc "Where to find the package file. This is mostly used by providers that don't
         automatically download packages from a central repository. (For example:
-        the `yum` provider ignores this attribute, `apt` provider uses it if present
+        the `macports` provider ignores this attribute, `apt` provider uses it if present
         and the `rpm` and `dpkg` providers require it.)
 
         Different providers accept different values for `source`. Most providers


### PR DESCRIPTION
The `yum` provider supports `source` now, so correct the docs.

https://github.com/puppetlabs/puppet/pull/6296