### PR TITLE
Use token when checking out repo

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
 
       - name: Add SSH key
         run: |


### PR DESCRIPTION
This is how we allow the action to push to the protected branch.