### PR TITLE
Update augeas test to detect provider failure

### DIFF
--- a/packaging/acceptance/tests/augeas_validation.rb
+++ b/packaging/acceptance/tests/augeas_validation.rb
@@ -32,7 +32,7 @@ augeas { 'test_ssh':
   ]
 }
 EOF
-      assert_equal(on(agent, "puppet apply -e \"#{file}\"").exit_code, 0, 'Puppet apply of the augeas resource returned a non-zero exit code')
+      on(agent, "puppet apply -e \"#{file}\" --detailed-exitcodes", acceptable_exit_codes: [2])
     end
   end
 end


### PR DESCRIPTION
Apparently, when a provider can't be found, the agent still exits 0.
This uses --detailed-exitcodes so we can accurately test success (2) or
failure (4).