### PR TITLE
Be a bit more verbose when loading module facts

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -69,7 +69,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       # print out each .rb in the facts directory as module
       # developers may find that information useful for debugging purposes
       if Puppet::Util::Log.sendlevel?(:info)
-        Puppet.info _("Loading facts")
+        Puppet.info _("Loading facts from module #{File.basename(File.expand_path('../..', dir))}.")
         Dir.glob("#{dir}/*.rb").each do |file|
           Puppet.debug { "Loading facts from #{file}" }
         end


### PR DESCRIPTION
Right now, you only get a rather unhelpful pile of `Loading facts` messages when having a log level of info. This changes the messages so that it's clear which module's facts are loaded and you're not staring at a bunch of info-level messages that are only understandable when you're actually at debug level.