### PR TITLE
Include missing EC2 stub request

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -159,6 +159,7 @@ RSpec.configure do |config|
   # Facter EC2 endpoint
   PUPPET_FACTER_EC2_METADATA = 'http://169.254.169.254/latest/meta-data/'
   PUPPET_FACTER_EC2_USERDATA = 'http://169.254.169.254/latest/user-data/'
+  PUPPET_FACTER_EC2_API_TOKEN = 'http://169.254.169.254/latest/api/token' # see https://github.com/puppetlabs/facter/issues/2690
 
   config.around :each do |example|
     # Ignore requests from Facter to external services
@@ -167,6 +168,7 @@ RSpec.configure do |config|
     stub_request(:get, PUPPET_FACTER_AZ_URL)
     stub_request(:get, PUPPET_FACTER_EC2_METADATA)
     stub_request(:get, PUPPET_FACTER_EC2_USERDATA)
+    stub_request(:put, PUPPET_FACTER_EC2_API_TOKEN)
 
     # Enable VCR if the example is tagged with `:vcr` metadata.
     if example.metadata[:vcr]


### PR DESCRIPTION
I'm trying to run the full test suite locally (on Ubuntu LTS and on CentOS Stream 10) but I keep getting failures on several tests related to Facter. Here is a snippet of the output of one of such tests:

```
1) Puppet::Node::Facts::Facter preserves case in fact values
   Failure/Error: ::Facter.resolve(options)
   WebMock::NetConnectNotAllowedError:
     Real HTTP connections are disabled. Unregistered request: PUT http://169.254.169.254/latest/api/token with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby', 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'100'}
```

The reason, I believe, is a leaked EC2 request due to the following bug in Facter: https://github.com/puppetlabs/facter/issues/2690. This PR adds the leaked EC2 request as a stub request in the test suite.