### PR TITLE
Do not explicitly disable SSLv3

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -52,12 +52,6 @@ end
 require_relative '../../puppet/ssl/openssl_loader'
 unless Puppet::Util::Platform.jruby_fips?
   class OpenSSL::SSL::SSLContext
-    if DEFAULT_PARAMS[:options]
-      DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_NO_SSLv3
-    else
-      DEFAULT_PARAMS[:options] = OpenSSL::SSL::OP_NO_SSLv3
-    end
-
     alias __original_initialize initialize
     private :__original_initialize
 

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -71,17 +71,6 @@ describe Symbol do
 end
 
 describe OpenSSL::SSL::SSLContext do
-  it 'disables SSLv3 via the SSLContext#options bitmask' do
-    expect(subject.options & OpenSSL::SSL::OP_NO_SSLv3).to eq(OpenSSL::SSL::OP_NO_SSLv3)
-  end
-
-  it 'does not exclude SSLv3 ciphers shared with TLSv1' do
-    cipher_str = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]
-    if cipher_str
-      expect(cipher_str.split(':')).not_to include('!SSLv3')
-    end
-  end
-
   it 'sets parameters on initialization' do
     expect_any_instance_of(described_class).to receive(:set_params)
     subject


### PR DESCRIPTION
SSLv3 is long gone, we could also probably also disable TLS 1.0 and 1.1,
but [recent changes in the openssl gem freeze the default parameters](https://github.com/ruby/openssl/pull/925), and
the default configuration seems to have the correct behavior on the
systems I tested, refusing to connect to hosts with anything older than
TLS 1.2.

Drop this monkey patching to unbreak with version 4.0.0 of the openssl
gem.

Fixes https://github.com/OpenVoxProject/openbolt/issues/169
