### PR TITLE
Generate the reference from the runmode

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -2,6 +2,10 @@
 
 config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc => "A reference for all settings") do
   str = +''
+  unix_runmode_root = Puppet::Util::UnixRunMode.new(:server, true, false)
+  unix_runmode_user = Puppet::Util::UnixRunMode.new(:server, false, false)
+  windows_runmode = Puppet::Util::WindowsRunMode.new(:server, true, false)
+
   Puppet.settings.sort_by { |name, _| name.to_s }.each do |name, object|
     # Make each name an anchor
     header = name.to_s
@@ -18,17 +22,17 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     # Now print the data about the item.
     val = case name.to_s
           when 'vardir'
-            'Unix/Linux: /opt/puppetlabs/puppet/cache -- Windows: C:\ProgramData\PuppetLabs\puppet\cache -- Non-root user: ~/.puppetlabs/opt/puppet/cache'
+            "Unix/Linux: #{unix_runmode_root.var_dir} -- Windows: #{windows_runmode.var_dir} -- Non-root user: #{unix_runmode_user.var_dir}"
           when 'publicdir'
-            'Unix/Linux: /opt/puppetlabs/puppet/public -- Windows: C:\ProgramData\PuppetLabs\puppet\public -- Non-root user: ~/.puppetlabs/opt/puppet/public'
+            "Unix/Linux: #{unix_runmode_root.public_dir} -- Windows: #{windows_runmode.public_dir} -- Non-root user: #{unix_runmode_user.public_dir}"
           when 'confdir'
-            'Unix/Linux: /etc/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\etc -- Non-root user: ~/.puppetlabs/etc/puppet'
+            "Unix/Linux: #{unix_runmode_root.conf_dir} -- Windows: #{windows_runmode.conf_dir} -- Non-root user: #{unix_runmode_user.conf_dir}"
           when 'codedir'
-            'Unix/Linux: /etc/puppetlabs/code -- Windows: C:\ProgramData\PuppetLabs\code -- Non-root user: ~/.puppetlabs/etc/code'
+            "Unix/Linux: #{unix_runmode_root.code_dir} -- Windows: #{windows_runmode.code_dir} -- Non-root user: #{unix_runmode_user.code_dir}"
           when 'rundir'
-            'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
+            "Unix/Linux: #{unix_runmode_root.run_dir} -- Windows: #{windows_runmode.run_dir} -- Non-root user: #{unix_runmode_user.run_dir}"
           when 'logdir'
-            'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
+            "Unix/Linux: #{unix_runmode_root.log_dir} -- Windows: #{windows_runmode.log_dir} -- Non-root user: #{unix_runmode_user.log_dir}"
           when 'hiera_config'
             '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
           when 'certname'

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
 config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc => "A reference for all settings") do
-  docs = {}
-  Puppet.settings.each do |name, object|
-    docs[name] = object
-  end
-
-  str = ''.dup
-  docs.sort { |a, b|
-    a[0].to_s <=> b[0].to_s
-  }.each do |name, object|
+  str = +''
+  Puppet.settings.sort_by { |name, _| name.to_s }.each do |name, object|
     # Make each name an anchor
     header = name.to_s
     str << markdown_header(header, 3)
@@ -23,33 +16,34 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     str << "\n\n"
 
     # Now print the data about the item.
-    val = object.default
-    case name.to_s
-    when 'vardir'
-      val = 'Unix/Linux: /opt/puppetlabs/puppet/cache -- Windows: C:\ProgramData\PuppetLabs\puppet\cache -- Non-root user: ~/.puppetlabs/opt/puppet/cache'
-    when 'publicdir'
-      val = 'Unix/Linux: /opt/puppetlabs/puppet/public -- Windows: C:\ProgramData\PuppetLabs\puppet\public -- Non-root user: ~/.puppetlabs/opt/puppet/public'
-    when 'confdir'
-      val = 'Unix/Linux: /etc/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\etc -- Non-root user: ~/.puppetlabs/etc/puppet'
-    when 'codedir'
-      val = 'Unix/Linux: /etc/puppetlabs/code -- Windows: C:\ProgramData\PuppetLabs\code -- Non-root user: ~/.puppetlabs/etc/code'
-    when 'rundir'
-      val = 'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
-    when 'logdir'
-      val = 'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
-    when 'hiera_config'
-      val = '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
-    when 'certname'
-      val = "the Host's fully qualified domain name, as determined by Facter"
-    when 'hostname'
-      val = "(the system's fully qualified hostname)"
-    when 'domain'
-      val = "(the system's own domain)"
-    when 'srv_domain'
-      val = 'example.com'
-    when 'http_user_agent'
-      val = 'Puppet/<version> Ruby/<version> (<architecture>)'
-    end
+    val = case name.to_s
+          when 'vardir'
+            'Unix/Linux: /opt/puppetlabs/puppet/cache -- Windows: C:\ProgramData\PuppetLabs\puppet\cache -- Non-root user: ~/.puppetlabs/opt/puppet/cache'
+          when 'publicdir'
+            'Unix/Linux: /opt/puppetlabs/puppet/public -- Windows: C:\ProgramData\PuppetLabs\puppet\public -- Non-root user: ~/.puppetlabs/opt/puppet/public'
+          when 'confdir'
+            'Unix/Linux: /etc/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\etc -- Non-root user: ~/.puppetlabs/etc/puppet'
+          when 'codedir'
+            'Unix/Linux: /etc/puppetlabs/code -- Windows: C:\ProgramData\PuppetLabs\code -- Non-root user: ~/.puppetlabs/etc/code'
+          when 'rundir'
+            'Unix/Linux: /var/run/puppetlabs -- Windows: C:\ProgramData\PuppetLabs\puppet\var\run -- Non-root user: ~/.puppetlabs/var/run'
+          when 'logdir'
+            'Unix/Linux: /var/log/puppetlabs/puppet -- Windows: C:\ProgramData\PuppetLabs\puppet\var\log -- Non-root user: ~/.puppetlabs/var/log'
+          when 'hiera_config'
+            '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
+          when 'certname'
+            "the Host's fully qualified domain name, as determined by Facter"
+          when 'hostname'
+            "(the system's fully qualified hostname)"
+          when 'domain'
+            "(the system's own domain)"
+          when 'srv_domain'
+            'example.com'
+          when 'http_user_agent'
+            'Puppet/<version> Ruby/<version> (<architecture>)'
+          else
+            object.default
+          end
 
     # Leave out the section information; it was apparently confusing people.
     # str << "- **Section**: #{object.section}\n"

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -107,27 +107,27 @@ module Puppet
 
     class WindowsRunMode < RunMode
       def conf_dir
-        which_dir(File.join(windows_common_base("puppet/etc")), "~/.puppetlabs/etc/puppet")
+        which_dir("puppet/etc", "etc/puppet")
       end
 
       def code_dir
-        which_dir(File.join(windows_common_base("code")), "~/.puppetlabs/etc/code")
+        which_dir("code", "etc/code")
       end
 
       def var_dir
-        which_dir(File.join(windows_common_base("puppet/cache")), "~/.puppetlabs/opt/puppet/cache")
+        which_dir("puppet/cache", "opt/puppet/cache")
       end
 
       def public_dir
-        which_dir(File.join(windows_common_base("puppet/public")), "~/.puppetlabs/opt/puppet/public")
+        which_dir("puppet/public", "opt/puppet/public")
       end
 
       def run_dir
-        which_dir(File.join(windows_common_base("puppet/var/run")), "~/.puppetlabs/var/run")
+        which_dir("puppet/var/run", "var/run")
       end
 
       def log_dir
-        which_dir(File.join(windows_common_base("puppet/var/log")), "~/.puppetlabs/var/log")
+        which_dir("puppet/var/log", "var/log")
       end
 
       def pkg_config_path
@@ -151,6 +151,10 @@ module Puppet
       end
 
       private
+
+      def which_dir(system, user)
+        super(File.join(windows_common_base(system)), File.join('~/.puppetlabs', user))
+      end
 
       def installdir
         ENV.fetch('FACTER_env_windows_installdir', nil)

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -5,8 +5,10 @@ require 'etc'
 module Puppet
   module Util
     class RunMode
-      def initialize(name)
+      def initialize(name, root = nil, expand = true)
         @name = name.to_sym
+        @root = root.nil? ? Puppet.features.root? : root
+        @expand = expand
       end
 
       attr_reader :name
@@ -55,11 +57,8 @@ module Puppet
       # @todo this code duplicates {Puppet::Settings#which\_configuration\_file}
       #   as described in {https://projects.puppetlabs.com/issues/16637 #16637}
       def which_dir(system, user)
-        if Puppet.features.root?
-          File.expand_path(system)
-        else
-          File.expand_path(user)
-        end
+        value = @root ? system : user
+        @expand ? File.expand_path(value) : value
       end
     end
 

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -160,7 +160,7 @@ module Puppet
       end
 
       def windows_common_base(*extra)
-        [ENV.fetch('ALLUSERSPROFILE', nil), "PuppetLabs"] + extra
+        [ENV.fetch('ALLUSERSPROFILE', 'C:\ProgramData'), "PuppetLabs"] + extra
       end
     end
   end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -1,85 +1,76 @@
 require 'spec_helper'
 
 describe Puppet::Util::RunMode do
-  before do
-    @run_mode = Puppet::Util::RunMode.new('fake')
-  end
+  let(:name) { 'fake' }
+  let(:run_mode) { described_class.new(name) }
 
   describe Puppet::Util::UnixRunMode, :unless => Puppet::Util::Platform.windows? do
-    before do
-      @run_mode = Puppet::Util::UnixRunMode.new('fake')
-    end
-
     describe "#conf_dir" do
       it "has confdir /etc/puppetlabs/puppet when run as root" do
-        as_root { expect(@run_mode.conf_dir).to eq(File.expand_path('/etc/puppetlabs/puppet')) }
+        as_root { expect(run_mode.conf_dir).to eq(File.expand_path('/etc/puppetlabs/puppet')) }
       end
 
       it "has confdir ~/.puppetlabs/etc/puppet when run as non-root" do
-        as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
+        as_non_root { expect(run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
       end
 
       context "server run mode" do
-        before do
-          @run_mode = Puppet::Util::UnixRunMode.new('server')
-        end
+        let(:name) { 'server' }
 
         it "has confdir ~/.puppetlabs/etc/puppet when run as non-root and server run mode" do
-          as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
+          as_non_root { expect(run_mode.conf_dir).to eq(File.expand_path('~/.puppetlabs/etc/puppet')) }
         end
       end
     end
 
     describe "#code_dir" do
       it "has codedir /etc/puppetlabs/code when run as root" do
-        as_root { expect(@run_mode.code_dir).to eq(File.expand_path('/etc/puppetlabs/code')) }
+        as_root { expect(run_mode.code_dir).to eq(File.expand_path('/etc/puppetlabs/code')) }
       end
 
       it "has codedir ~/.puppetlabs/etc/code when run as non-root" do
-        as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
+        as_non_root { expect(run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
       end
 
       context "server run mode" do
-        before do
-          @run_mode = Puppet::Util::UnixRunMode.new('server')
-        end
+        let(:name) { 'server' }
 
         it "has codedir ~/.puppetlabs/etc/code when run as non-root and server run mode" do
-          as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
+          as_non_root { expect(run_mode.code_dir).to eq(File.expand_path('~/.puppetlabs/etc/code')) }
         end
       end
     end
 
     describe "#var_dir" do
       it "has vardir /opt/puppetlabs/puppet/cache when run as root" do
-        as_root { expect(@run_mode.var_dir).to eq(File.expand_path('/opt/puppetlabs/puppet/cache')) }
+        as_root { expect(run_mode.var_dir).to eq(File.expand_path('/opt/puppetlabs/puppet/cache')) }
       end
 
       it "has vardir ~/.puppetlabs/opt/puppet/cache when run as non-root" do
-        as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/cache')) }
+        as_non_root { expect(run_mode.var_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/cache')) }
       end
     end
 
     describe "#public_dir" do
       it "has publicdir /opt/puppetlabs/puppet/public when run as root" do
-        as_root { expect(@run_mode.public_dir).to eq(File.expand_path('/opt/puppetlabs/puppet/public')) }
+        as_root { expect(run_mode.public_dir).to eq(File.expand_path('/opt/puppetlabs/puppet/public')) }
       end
 
       it "has publicdir ~/.puppetlabs/opt/puppet/public when run as non-root" do
-        as_non_root { expect(@run_mode.public_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/public')) }
+        as_non_root { expect(run_mode.public_dir).to eq(File.expand_path('~/.puppetlabs/opt/puppet/public')) }
       end
     end
 
     describe "#log_dir" do
       describe "when run as root" do
         it "has logdir /var/log/puppetlabs/puppet" do
-          as_root { expect(@run_mode.log_dir).to eq(File.expand_path('/var/log/puppetlabs/puppet')) }
+          as_root { expect(run_mode.log_dir).to eq(File.expand_path('/var/log/puppetlabs/puppet')) }
         end
       end
 
       describe "when run as non-root" do
         it "has default logdir ~/.puppetlabs/var/log" do
-          as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
+          as_non_root { expect(run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
       end
     end
@@ -87,89 +78,85 @@ describe Puppet::Util::RunMode do
     describe "#run_dir" do
       describe "when run as root" do
         it "has rundir /var/run/puppetlabs" do
-          as_root { expect(@run_mode.run_dir).to eq(File.expand_path('/var/run/puppetlabs')) }
+          as_root { expect(run_mode.run_dir).to eq(File.expand_path('/var/run/puppetlabs')) }
         end
       end
 
       describe "when run as non-root" do
         it "has default rundir ~/.puppetlabs/var/run" do
-          as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
+          as_non_root { expect(run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
       end
     end
 
     describe "#pkg_config_path" do
-      it { expect(@run_mode.pkg_config_path).to eq('/opt/puppetlabs/puppet/lib/pkgconfig') }
+      it { expect(run_mode.pkg_config_path).to eq('/opt/puppetlabs/puppet/lib/pkgconfig') }
     end
 
     describe "#gem_cmd" do
-      it { expect(@run_mode.gem_cmd).to eq('/opt/puppetlabs/puppet/bin/gem') }
+      it { expect(run_mode.gem_cmd).to eq('/opt/puppetlabs/puppet/bin/gem') }
     end
 
     describe "#common_module_dir" do
-      it { expect(@run_mode.common_module_dir).to eq('/opt/puppetlabs/puppet/modules') }
+      it { expect(run_mode.common_module_dir).to eq('/opt/puppetlabs/puppet/modules') }
     end
 
     describe "#vendor_module_dir" do
-      it { expect(@run_mode.vendor_module_dir).to eq('/opt/puppetlabs/puppet/vendor_modules') }
+      it { expect(run_mode.vendor_module_dir).to eq('/opt/puppetlabs/puppet/vendor_modules') }
     end
   end
 
   describe Puppet::Util::WindowsRunMode, :if => Puppet::Util::Platform.windows? do
-    before do
-      @run_mode = Puppet::Util::WindowsRunMode.new('fake')
-    end
-
     describe "#conf_dir" do
       it "has confdir ending in Puppetlabs/puppet/etc when run as root" do
-        as_root { expect(@run_mode.conf_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "etc"))) }
+        as_root { expect(run_mode.conf_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "etc"))) }
       end
 
       it "has confdir in ~/.puppetlabs/etc/puppet when run as non-root" do
-        as_non_root { expect(@run_mode.conf_dir).to eq(File.expand_path("~/.puppetlabs/etc/puppet")) }
+        as_non_root { expect(run_mode.conf_dir).to eq(File.expand_path("~/.puppetlabs/etc/puppet")) }
       end
     end
 
     describe "#code_dir" do
       it "has codedir ending in PuppetLabs/code when run as root" do
-        as_root { expect(@run_mode.code_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "code"))) }
+        as_root { expect(run_mode.code_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "code"))) }
       end
 
       it "has codedir in ~/.puppetlabs/etc/code when run as non-root" do
-        as_non_root { expect(@run_mode.code_dir).to eq(File.expand_path("~/.puppetlabs/etc/code")) }
+        as_non_root { expect(run_mode.code_dir).to eq(File.expand_path("~/.puppetlabs/etc/code")) }
       end
     end
 
     describe "#var_dir" do
       it "has vardir ending in PuppetLabs/puppet/cache when run as root" do
-        as_root { expect(@run_mode.var_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "cache"))) }
+        as_root { expect(run_mode.var_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "cache"))) }
       end
 
       it "has vardir in ~/.puppetlabs/opt/puppet/cache when run as non-root" do
-        as_non_root { expect(@run_mode.var_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/cache")) }
+        as_non_root { expect(run_mode.var_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/cache")) }
       end
     end
 
     describe "#public_dir" do
       it "has publicdir ending in PuppetLabs/puppet/public when run as root" do
-        as_root { expect(@run_mode.public_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "public"))) }
+        as_root { expect(run_mode.public_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "public"))) }
       end
 
       it "has publicdir in ~/.puppetlabs/opt/puppet/public when run as non-root" do
-        as_non_root { expect(@run_mode.public_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/public")) }
+        as_non_root { expect(run_mode.public_dir).to eq(File.expand_path("~/.puppetlabs/opt/puppet/public")) }
       end
     end
 
     describe "#log_dir" do
       describe "when run as root" do
         it "has logdir ending in PuppetLabs/puppet/var/log" do
-          as_root { expect(@run_mode.log_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "log"))) }
+          as_root { expect(run_mode.log_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "log"))) }
         end
       end
 
       describe "when run as non-root" do
         it "has default logdir ~/.puppetlabs/var/log" do
-          as_non_root { expect(@run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
+          as_non_root { expect(run_mode.log_dir).to eq(File.expand_path('~/.puppetlabs/var/log')) }
         end
       end
     end
@@ -177,13 +164,13 @@ describe Puppet::Util::RunMode do
     describe "#run_dir" do
       describe "when run as root" do
         it "has rundir ending in PuppetLabs/puppet/var/run" do
-          as_root { expect(@run_mode.run_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "run"))) }
+          as_root { expect(run_mode.run_dir).to eq(File.expand_path(File.join(ENV['ALLUSERSPROFILE'], "PuppetLabs", "puppet", "var", "run"))) }
         end
       end
 
       describe "when run as non-root" do
         it "has default rundir ~/.puppetlabs/var/run" do
-          as_non_root { expect(@run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
+          as_non_root { expect(run_mode.run_dir).to eq(File.expand_path('~/.puppetlabs/var/run')) }
         end
       end
     end
@@ -203,7 +190,7 @@ describe Puppet::Util::RunMode do
 
         it 'uses Gem.default_bindir' do
           expected_path = File.join('default_gem_bin', 'gem.bat')
-          expect(@run_mode.gem_cmd).to eql(expected_path)
+          expect(run_mode.gem_cmd).to eql(expected_path)
         end
       end
 
@@ -212,7 +199,7 @@ describe Puppet::Util::RunMode do
 
         it 'uses Gem.default_bindir' do
           expected_path = File.join('puppet_dir', 'bin', 'gem.bat')
-          expect(@run_mode.gem_cmd).to eql(expected_path)
+          expect(run_mode.gem_cmd).to eql(expected_path)
         end
       end
     end
@@ -227,7 +214,7 @@ describe Puppet::Util::RunMode do
         let(:installdir) { nil }
 
         it 'returns nil' do
-          expect(@run_mode.common_module_dir).to be(nil)
+          expect(run_mode.common_module_dir).to be(nil)
         end
       end
 
@@ -235,7 +222,7 @@ describe Puppet::Util::RunMode do
         let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
 
         it 'returns INSTALLDIR/puppet/modules' do
-          expect(@run_mode.common_module_dir).to eq('C:\Program Files\Puppet Labs\Puppet/puppet/modules')
+          expect(run_mode.common_module_dir).to eq('C:\Program Files\Puppet Labs\Puppet/puppet/modules')
         end
       end
     end
@@ -250,7 +237,7 @@ describe Puppet::Util::RunMode do
         let(:installdir) { nil }
 
         it 'returns nil' do
-          expect(@run_mode.vendor_module_dir).to be(nil)
+          expect(run_mode.vendor_module_dir).to be(nil)
         end
       end
 
@@ -258,7 +245,7 @@ describe Puppet::Util::RunMode do
         let(:installdir) { 'C:\Program Files\Puppet Labs\Puppet' }
 
         it 'returns INSTALLDIR\puppet\vendor_modules' do
-          expect(@run_mode.vendor_module_dir).to eq('C:\Program Files\Puppet Labs\Puppet\puppet\vendor_modules')
+          expect(run_mode.vendor_module_dir).to eq('C:\Program Files\Puppet Labs\Puppet\puppet\vendor_modules')
         end
       end
     end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Puppet::Util::RunMode do
   let(:name) { 'fake' }
-  let(:run_mode) { described_class.new(name) }
+  let(:run_mode) { described_class.new(name, root) }
+  let(:root) { @root }
 
   describe Puppet::Util::UnixRunMode, :unless => Puppet::Util::Platform.windows? do
     describe "#conf_dir" do
@@ -252,12 +253,12 @@ describe Puppet::Util::RunMode do
   end
 
   def as_root
-    allow(Puppet.features).to receive(:root?).and_return(true)
+    @root = true
     yield
   end
 
   def as_non_root
-    allow(Puppet.features).to receive(:root?).and_return(false)
+    @root = false
     yield
   end
 end


### PR DESCRIPTION
This avoids duplicating the values with the actual logic.

The motivation is to fully centralize all OS specific paths in `RunMode`. If packaging decides to change it (like in https://github.com/OpenVoxProject/openvox/pull/225) then it is limited to a single file.