### PR TITLE
Drop multi_json support

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('fast_gettext', '>= 2.1', '< 5')
   spec.add_runtime_dependency('getoptlong', '~> 0.2.0')
   spec.add_runtime_dependency('locale', '~> 2.1')
-  spec.add_runtime_dependency('multi_json', '~> 1.13')
   spec.add_runtime_dependency('openfact', '~> 5.0')
   spec.add_runtime_dependency('ostruct', '>= 0.5.5', '< 0.7')
   spec.add_runtime_dependency('puppet-resource_api', '~> 2.0')

--- a/rakelib/benchmark.rake
+++ b/rakelib/benchmark.rake
@@ -1,6 +1,5 @@
 require 'benchmark'
 require 'tmpdir'
-require 'csv'
 require 'objspace'
 
 namespace :benchmark do
@@ -37,6 +36,8 @@ namespace :benchmark do
 
       desc "Run the #{name} scenario."
       task :run, [*run_args] =>  :generate do |_, args|
+        require 'csv'
+
         report = []
         details = []
         Benchmark.benchmark(Benchmark::CAPTION, 10, Benchmark::FORMAT, "> total:", "> avg:") do |b|

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -368,12 +368,6 @@ describe "Puppet Network Format" do
       expect(json.render_multiple(instances)).to eq([{"string" => "foo"}].to_json)
     end
 
-    it "should render multiple instances as a JSON array of hashes when multi_json is not present" do
-      hide_const("MultiJson") if defined?(MultiJson)
-      instances = [FormatsTest.new("foo")]
-      expect(json.render_multiple(instances)).to eq([{"string" => "foo"}].to_json)
-    end
-
     it "should intern an instance from a JSON hash" do
       text = Puppet::Util::Json.dump({"string" => "parsed_json"})
       instance = json.intern(FormatsTest, text)


### PR DESCRIPTION
These days the built in JSON is fast enough and supporting other implementations can only complicate matters. We can also rely on JRuby to have a correct implementation since the same json gem is also built for Java and included in JRuby.

Note I made an assumption about JRuby because https://rubygems.org/gems/json also lists a Java build.

I was triggered to drop this because tests started to fail for me.