### PR TITLE
Use usermod(8) on OpenBSD to unbreak password management

### DIFF
--- a/lib/puppet/provider/user/openbsd.rb
+++ b/lib/puppet/provider/user/openbsd.rb
@@ -76,4 +76,19 @@ Puppet::Type.type(:user).provide :openbsd, :parent => :useradd do
     end
     cmd
   end
+
+  def password=(value)
+    user = @resource.name
+    begin
+      cmd = [command(:modify), '-p', value, user]
+      execute_options = {
+        :failonfail => true,
+        :combine => true,
+        :sensitive => has_sensitive_data?
+      }
+      execute(cmd, execute_options)
+    rescue => detail
+      raise Puppet::Error, "Could not set password on #{@resource.class.name}[#{@resource.name}]: #{detail}", detail.backtrace
+    end
+  end
 end


### PR DESCRIPTION
f1e77c23e3 "(PUP-3634) Hide password hash from process list for useradd"
introduced `chpasswd -e` which does not exist on OpenBSD, thus `user`
resources managing `password` would always fail:

```
Notice: Compiled catalog for atar in environment production in 0.02 seconds
rror: Could not set password on user[test]: No command chpasswd defined for provider openbsd
Error: /Stage[main]/Main/User[test]/password: change from [redacted] to [redacted] failed: Could not set password on user[test]: No command chpasswd defined for provider openbsd
Notice: Applied catalog in 0.01 seconds
```

Use https://man.openbsd.org/usermod.8#p instead:

```
Notice: Compiled catalog for atar in environment production in 0.01 seconds
Notice: /Stage[main]/Main/User[test]/password: changed [redacted] to [redacted]
Notice: Applied catalog in 0.21 seconds
```

`password` values now do show up briefly in the process list, but given
they must be encrypted in order to work, this does not seem critical.
