### PR TITLE
Remove monkey patch to remove daemonize

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -22,15 +22,6 @@ module RDoc
   end
 end
 
-class Object
-  # ActiveSupport 2.3.x mixes in a dangerous method
-  # that can cause rspec to fork bomb
-  # and other strange things like that.
-  def daemonize
-    raise NotImplementedError, "Kernel.daemonize is too dangerous, please don't try to use it."
-  end
-end
-
 unless Dir.singleton_methods.include?(:exists?)
   class Dir
     def self.exists?(file_name)


### PR DESCRIPTION
ActiveSupport 3.0.0 dropped this method, which dates back to 2010. It's safe to assume nobody uses such an old version anymore.