### PR TITLE
Reduce OpenSSL monkey patch to only calling set_params

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -57,11 +57,7 @@ unless Puppet::Util::Platform.jruby_fips?
 
     def initialize(*args)
       __original_initialize(*args)
-      params = {
-        :options => DEFAULT_PARAMS[:options],
-        :ciphers => DEFAULT_PARAMS[:ciphers],
-      }
-      set_params(params)
+      set_params
     end
   end
 end


### PR DESCRIPTION
ruby-openssl has always merged the passed params with default params, so this is redundant.

It's still a difference that the default SSLContext does not call `set_params` and expects the caller to do so.

Link: https://github.com/ruby/openssl/blob/b814041f4fa2c64f0d2092c38bc2615a770f11c4/lib/openssl/ssl.rb#L113