### PR TITLE
fix: `Deferred` resolution of Puppet-language functions (e.g. mocks in tests) failing due to lack of `:global_scope`

### DIFF
--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -48,7 +48,10 @@ class DeferredResolver
     #    # Server facts are always about the local node's version etc.
     #    @scope.set_server_facts(node.server_facts)
 
-    resolver.resolve_futures(catalog)
+    # Must be wrapped in with_context_overrides to ensure global_scope is valid for Puppet-language functions
+    compiler.with_context_overrides do
+      resolver.resolve_futures(catalog)
+    end
     nil
   end
 

--- a/spec/unit/pops/evaluator/deferred_resolver_spec.rb
+++ b/spec/unit/pops/evaluator/deferred_resolver_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'puppet_spec/compiler'
+require 'puppet_spec/files'
 
 Puppet::Type.newtype(:test_deferred) do
   newparam(:name)
@@ -8,8 +9,14 @@ end
 
 describe Puppet::Pops::Evaluator::DeferredResolver do
   include PuppetSpec::Compiler
+  include PuppetSpec::Files
 
-  let(:environment) { Puppet::Node::Environment.create(:testing, []) }
+  let(:env_dir) do
+    dir_containing('testing', 'modules' => {
+      'testmod' => { 'functions' => { 'test.pp' => 'function testmod::test($x) { "Got: ${x}" }' } }
+    })
+  end
+  let(:environment) { Puppet::Node::Environment.create(:testing, [File.join(env_dir, 'modules')]) }
   let(:facts) { Puppet::Node::Facts.new('node.example.com') }
 
   def compile_and_resolve_catalog(code, preprocess = false)
@@ -94,5 +101,15 @@ describe Puppet::Pops::Evaluator::DeferredResolver do
 
     resource = catalog.resource(:test_deferred, 'deferred')
     expect(resource.sensitive_parameters).to eq([:value])
+  end
+
+  it 'resolves deferred values that call Puppet language functions' do
+    catalog = compile_and_resolve_catalog(<<~END, true)
+      notify { "deferred":
+        message => Deferred("testmod::test", ["hello"])
+      }
+    END
+
+    expect(catalog.resource(:notify, 'deferred')[:message]).to eq('Got: hello')
   end
 end


### PR DESCRIPTION
Hey folks, found an issue with Deferred resolution of Puppet-language functions while testing a control-repo with Onceover that makes heavy use of some custom functions that are mocked in Onceover's config, and did some digging.

The error was:
```
NoMethodError:
       undefined method `with_global_scope' for {}:Hash
```

Puppet-language functions use the `Named` `Closure`, which [explicitly looks up `:global_scope` ](https://github.com/griggi-ws/openvox/blob/d0274a2465ae71e9f74bf4ca547256814a599ddc/lib/puppet/pops/evaluator/closure.rb#L210-L211) and returns an empty Hash as a fallback. 

The `DeferredResolver` creates a new compiler instance [which includes `:global_scope` in its `context_overrides`](https://github.com/griggi-ws/openvox/blob/d0274a2465ae71e9f74bf4ca547256814a599ddc/lib/puppet/parser/compiler.rb#L167-L173), but the resolver's call to `resolve_futures` does not use them.

This means when a Puppet-lang Deferred function is resolved, `enclosing_scope` is `{}`, and when the `Closure`'s `invoke` is called  ([expecting a `Scope` object with the method `with_global_scope`](https://github.com/griggi-ws/openvox/blob/d0274a2465ae71e9f74bf4ca547256814a599ddc/lib/puppet/pops/evaluator/closure.rb#L71-L72)), it errors out since we have an empty `Hash` instead of a `Scope`.

By wrapping the `resolve_futures` call in a `compiler.with_context_overrides` block, `:global_scope` is a valid instance of `Scope`, and the function can be resolved. 


I added a spec test for Deferred processing of Puppet-lang functions, validated the failure, and applied the fix. 
