### PR TITLE
Fix filebucket REST terminus to support request.server

### DIFF
--- a/lib/puppet/indirector/file_bucket_file/rest.rb
+++ b/lib/puppet/indirector/file_bucket_file/rest.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'uri'
 require_relative '../../../puppet/indirector/rest'
 require_relative '../../../puppet/file_bucket/file'
 
@@ -9,7 +10,8 @@ module Puppet::FileBucketFile
 
     def head(request)
       session = Puppet.lookup(:http_session)
-      api = session.route_to(:puppet)
+      url = URI::HTTPS.build(host: request.server, port: request.port) if request.server
+      api = session.route_to(:puppet, url: url)
       api.head_filebucket_file(
         request.key,
         environment: request.environment.to_s,
@@ -23,7 +25,8 @@ module Puppet::FileBucketFile
 
     def find(request)
       session = Puppet.lookup(:http_session)
-      api = session.route_to(:puppet)
+      url = URI::HTTPS.build(host: request.server, port: request.port) if request.server
+      api = session.route_to(:puppet, url: url)
       _, filebucket_file = api.get_filebucket_file(
         request.key,
         environment: request.environment.to_s,
@@ -40,7 +43,8 @@ module Puppet::FileBucketFile
 
     def save(request)
       session = Puppet.lookup(:http_session)
-      api = session.route_to(:puppet)
+      url = URI::HTTPS.build(host: request.server, port: request.port) if request.server
+      api = session.route_to(:puppet, url: url)
       api.put_filebucket_file(
         request.key,
         body: request.instance.render,

--- a/spec/unit/indirector/file_bucket_file/rest_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/rest_spec.rb
@@ -86,4 +86,32 @@ describe Puppet::FileBucketFile::Rest do
       expect{described_class.indirection.save(file_bucket_file, dest_path)}.to raise_error(Net::HTTPError, "Error 503 on SERVER: server unavailable")
     end
   end
+
+  context 'when the request URI contains an explicit server' do
+    let(:server_uri) { %r{https://xanadu:8141/puppet/v3/file_bucket_file} }
+
+    describe '#head' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:head, server_uri)
+
+        described_class.indirection.head(file_bucket_path, :bucket_path => file_bucket_file.bucket_path)
+      end
+    end
+
+    describe '#find' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:get, server_uri).to_return(status: 200, headers: {'Content-Type' => 'application/octet-stream'})
+
+        described_class.indirection.find(source_path, :bucket_path => nil)
+      end
+    end
+
+    describe '#save' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:put, server_uri)
+
+        described_class.indirection.save(file_bucket_file, dest_path)
+      end
+    end
+  end
 end

--- a/spec/unit/indirector/file_bucket_file/rest_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/rest_spec.rb
@@ -90,4 +90,32 @@ describe Puppet::FileBucketFile::Rest do
       expect{described_class.indirection.save(file_bucket_file, dest_path)}.to raise_error(Net::HTTPError, "Error 503 on SERVER: server unavailable")
     end
   end
+
+  context 'when the request URI contains an explicit server' do
+    let(:server_uri) { %r{https://xanadu:8141/puppet/v3/file_bucket_file} }
+
+    describe '#head' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:head, server_uri)
+
+        described_class.indirection.head(file_bucket_path, :bucket_path => file_bucket_file.bucket_path)
+      end
+    end
+
+    describe '#find' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:get, server_uri).to_return(status: 200, headers: {'Content-Type' => 'application/octet-stream'})
+
+        described_class.indirection.find(source_path, :bucket_path => nil)
+      end
+    end
+
+    describe '#save' do
+      it 'routes the request to the server in the filebucket URI' do
+        stub_request(:put, server_uri)
+
+        described_class.indirection.save(file_bucket_file, dest_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The REST terminus called session.route_to(:puppet) with no URL, so route_to always resolved via the normal resolver chain and sent filebucket traffic to Puppet[:server], silently ignoring the server value encoded in the filebucket:// URI.

Co-Authored-By: Claude <noreply@anthropic.com>

Closes: #367