### PR TITLE
deprecate sha1() Puppet function

### DIFF
--- a/lib/puppet/parser/functions/sha1.rb
+++ b/lib/puppet/parser/functions/sha1.rb
@@ -2,6 +2,14 @@
 
 require 'digest/sha1'
 
-Puppet::Parser::Functions.newfunction(:sha1, :type => :rvalue, :arity => 1, :doc => "Returns a SHA1 hash value from a provided string.") do |args|
+Puppet::Parser::Functions.newfunction(:sha1, :type => :rvalue, :arity => 1, :doc => "Returns a SHA1 hash value from a provided string.
+
+  *Deprecated:* this function will be removed in a future release. Use the
+  `sha256()` function from the `puppetlabs-stdlib` module instead.") do |args|
+  Puppet.puppet_deprecation_warning(
+    _("The sha1() function is deprecated and will be removed in a future release. " \
+      "Use the sha256() function from the puppetlabs-stdlib module instead."),
+    key: 'puppet-sha1-function-deprecated'
+  )
   Digest::SHA1.hexdigest(args[0])
 end


### PR DESCRIPTION
SHA1 is no longer considered safe for new use. Emit a puppet_deprecation_warning on every call to sha1() directing users to the sha256() function from puppetlabs-stdlib.

### Short description
SHA1 is no longer considered safe for new use. Emit a puppet_deprecation_warning on every call to sha1() directing users to the sha256() function from puppetlabs-stdlib.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
