### PR TITLE
Remove pluginsync setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2035,16 +2035,6 @@ EOT
       is used for retrieval, so anything that is a valid file source can
       be used here.",
     },
-    :pluginsync => {
-      :default    => true,
-      :type       => :boolean,
-      :desc       => "Whether plugins should be synced with the central server. This setting is
-        deprecated.",
-      :hook => proc { |_value|
-        #TRANSLATORS 'pluginsync' is a setting and should not be translated
-        Puppet.deprecation_warning(_("Setting 'pluginsync' is deprecated."))
-      }
-    },
     :pluginsignore => {
         :default  => ".svn CVS .git .hg",
         :desc     => "What files to ignore when pulling down plugins.",

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2027,16 +2027,6 @@ EOT
       is used for retrieval, so anything that is a valid file source can
       be used here.",
     },
-    :pluginsync => {
-      :default    => true,
-      :type       => :boolean,
-      :desc       => "Whether plugins should be synced with the central server. This setting is
-        deprecated.",
-      :hook => proc { |_value|
-        #TRANSLATORS 'pluginsync' is a setting and should not be translated
-        Puppet.deprecation_warning(_("Setting 'pluginsync' is deprecated."))
-      }
-    },
     :pluginsignore => {
         :default  => ".svn CVS .git .hg",
         :desc     => "What files to ignore when pulling down plugins.",


### PR DESCRIPTION
### Short description
The pluginsync setting has been removed. Plugin synchronization is now always enabled.

Closes #339 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
