### PR TITLE
Remove regsubst encoding argument

### DIFF
--- a/lib/puppet/functions/regsubst.rb
+++ b/lib/puppet/functions/regsubst.rb
@@ -19,11 +19,7 @@ Puppet::Functions.create_function(:regsubst) do
   #        - *I*         Ignore case in regexps
   #        - *M*         Multiline regexps
   #        - *G*         Global replacement; all occurrences of the regexp in each target string will be replaced.  Without this, only the first occurrence will be replaced.
-  # @param encoding [Enum['N','E','S','U']]
-  #      Deprecated and ignored parameter, included only for compatibility.
   # @return [Array[String], String] The result of the substitution. Result type is the same as for the target parameter.
-  # @deprecated
-  #   This method has the optional encoding parameter, which is ignored.
   # @example Get the third octet from the node's IP address:
   #   ```puppet
   #   $i3 = regsubst($ipaddress,'^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$','\\3')
@@ -33,7 +29,6 @@ Puppet::Functions.create_function(:regsubst) do
     param          'String',                              :pattern
     param          'Variant[String,Hash[String,String]]', :replacement
     optional_param 'Optional[Pattern[/^[GEIM]*$/]]',      :flags
-    optional_param "Enum['N','E','S','U']",               :encoding
   end
 
   # @param target [String, Array[String]]
@@ -65,14 +60,7 @@ Puppet::Functions.create_function(:regsubst) do
     optional_param 'Pattern[/^G?$/]',                     :flags
   end
 
-  def regsubst_string(target, pattern, replacement, flags = nil, encoding = nil)
-    if encoding
-      Puppet.warn_once(
-        'deprecations', 'regsubst_function_encoding',
-        _("The regsubst() function's encoding argument has been ignored since Ruby 1.9 and will be removed in a future release")
-      )
-    end
-
+  def regsubst_string(target, pattern, replacement, flags = nil)
     re_flags = 0
     operation = :sub
     unless flags.nil?

--- a/spec/unit/functions/regsubst_spec.rb
+++ b/spec/unit/functions/regsubst_spec.rb
@@ -21,19 +21,15 @@ describe 'the regsubst function' do
 
   context 'when using a string pattern' do
     it 'should raise an Error if there is less than 3 arguments' do
-      expect { regsubst('foo', 'bar') }.to raise_error(/expects between 3 and 5 arguments, got 2/)
+      expect { regsubst('foo', 'bar') }.to raise_error(/expects between 3 and 4 arguments, got 2/)
     end
 
-    it 'should raise an Error if there is more than 5 arguments' do
-      expect { regsubst('foo', 'bar', 'gazonk', 'G', 'U', 'y') }.to raise_error(/expects between 3 and 5 arguments, got 6/)
+    it 'should raise an Error if there is more than 4 arguments' do
+      expect { regsubst('foo', 'bar', 'gazonk', 'G', 'y') }.to raise_error(/expects between 3 and 4 arguments, got 5/)
     end
 
     it 'should raise an Error if given a bad flag' do
       expect { regsubst('foo', 'bar', 'gazonk', 'X') }.to raise_error(/parameter 'flags' expects an undef value or a match for Pattern\[\/\^\[GEIM\]\*\$\/\], got 'X'/)
-    end
-
-    it 'should raise an Error if given a bad encoding' do
-      expect { regsubst('foo', 'bar', 'gazonk', nil, 'X') }.to raise_error(/parameter 'encoding' expects a match for Enum\['E', 'N', 'S', 'U'\], got 'X'/)
     end
 
     it 'should raise an Error if given a bad regular expression' do
@@ -51,11 +47,11 @@ describe 'the regsubst function' do
 
   context 'when using a regexp pattern' do
     it 'should raise an Error if there is less than 3 arguments' do
-      expect { regsubst('foo', /bar/) }.to raise_error(/expects between 3 and 5 arguments, got 2/)
+      expect { regsubst('foo', /bar/) }.to raise_error(/expects between 3 and 4 arguments, got 2/)
     end
 
-    it 'should raise an Error if there is more than 5 arguments' do
-      expect { regsubst('foo', /bar/, 'gazonk', 'G', 'E', 'y') }.to raise_error(/expects between 3 and 5 arguments, got 6/)
+    it 'should raise an Error if there is more than 4 arguments' do
+      expect { regsubst('foo', /bar/, 'gazonk', 'G', 'E') }.to raise_error(/expects between 3 and 4 arguments, got 5/)
     end
 
     it 'should raise an Error if given a flag other thant G' do


### PR DESCRIPTION
### Short description
The encoding argument for the regsubst function has been removed as deprecated.

Closes #336

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
