### PR TITLE
Remove empty() numeric compatibility

### DIFF
--- a/lib/puppet/functions/empty.rb
+++ b/lib/puppet/functions/empty.rb
@@ -6,12 +6,7 @@
 # * `Array`, `Hash` - having zero entries
 # * `String`, `Binary` - having zero length
 #
-# For backwards compatibility with the stdlib function with the same name the
-# following data types are also accepted by the function instead of raising an error.
-# Using these is deprecated and will raise a warning:
-#
-# * `Numeric` - `false` is returned for all `Numeric` values.
-# * `Undef` - `true` is returned for all `Undef` values.
+# For backwards compatibility, `Undef` is also accepted and returns `true`.
 #
 # @example Using `empty`
 #
@@ -36,10 +31,6 @@ Puppet::Functions.create_function(:empty) do
     param 'String', :str
   end
 
-  dispatch :numeric_empty do
-    param 'Numeric', :num
-  end
-
   dispatch :binary_empty do
     param 'Binary', :bin
   end
@@ -60,14 +51,6 @@ Puppet::Functions.create_function(:empty) do
     str.empty?
   end
 
-  # For compatibility reasons - return false rather than error on floats and integers
-  # (Yes, it is strange)
-  #
-  def numeric_empty(num)
-    deprecation_warning_for('Numeric')
-    false
-  end
-
   def binary_empty(bin)
     bin.length == 0
   end
@@ -77,11 +60,5 @@ Puppet::Functions.create_function(:empty) do
   #
   def undef_empty(x)
     true
-  end
-
-  def deprecation_warning_for(arg_type)
-    file, line = Puppet::Pops::PuppetStack.top_of_stack
-    msg = _("Calling function empty() with %{arg_type} value is deprecated.") % { arg_type: arg_type }
-    Puppet.warn_once('deprecations', "empty-from-#{file}-#{line}", msg, file, line)
   end
 end

--- a/spec/unit/functions/empty_spec.rb
+++ b/spec/unit/functions/empty_spec.rb
@@ -30,22 +30,6 @@ describe 'the empty function' do
     end
   end
 
-  context 'for numeric values it' do
-    it 'always returns false for integer values (including 0)' do
-      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-        expect(compile_to_catalog("notify { String(empty(0)): }")).to have_resource('Notify[false]')
-      end
-      expect(warnings).to include(/Calling function empty\(\) with Numeric value is deprecated/)
-    end
-
-    it 'always returns false for float values (including 0.0)' do
-      Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-        expect(compile_to_catalog("notify { String(empty(0.0)): }")).to have_resource('Notify[false]')
-      end
-      expect(warnings).to include(/Calling function empty\(\) with Numeric value is deprecated/)
-    end
-  end
-
   context 'for a string it' do
     it 'returns true when empty' do
       expect(compile_to_catalog("notify { String(empty('')): }")).to have_resource('Notify[true]')


### PR DESCRIPTION
### Short description
Remove the deprecated numeric argument support from the empty() function, which previously allowed passing integers/floats as arguments.

Closes #346

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
