### PR TITLE
Add syslog as a runtime dependency

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('racc', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
+  spec.add_runtime_dependency('syslog', '~> 0.1')
   spec.add_runtime_dependency('win32ole', '>= 1.8', '< 2.0') if Gem.win_platform?
 
   platform = spec.platform.to_s


### PR DESCRIPTION
This is needed in Ruby 4 since it is now a bundled gem. Choosing ~> 0.1 allows this to work on older Ruby 3.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
