### PR TITLE
(#406) packaging: Set Maj.Min.Patch version as `provides` instead of major one

### DIFF
--- a/packaging/configs/projects/openvox-agent.rb
+++ b/packaging/configs/projects/openvox-agent.rb
@@ -85,7 +85,8 @@ project 'openvox-agent' do |proj|
   proj.vendor "Vox Pupuli <openvox@voxpupuli.org>"
   proj.homepage "https://voxpupuli.org"
 
-  major = proj.get_version.split('.').first
+  version = proj.get_version
+  major = version.split('.').first
   proj.target_repo "openvox#{major}"
 
   if platform.is_solaris?
@@ -100,7 +101,7 @@ project 'openvox-agent' do |proj|
   end
 
   # Set package version, for use by Facter in creating the AIO_AGENT_VERSION fact.
-  proj.setting(:package_version, proj.get_version)
+  proj.setting(:package_version, version)
 
   # Provides augeas, curl, libedit, libxml2, libxslt, openssl, puppet-ca-bundle, ruby and rubygem-*
   proj.component "puppet-runtime"
@@ -160,7 +161,7 @@ project 'openvox-agent' do |proj|
   # make sure we can replace puppet-agent in place for the rename
   proj.replaces 'puppet-agent', "< #{major.to_i + 1}"
   proj.conflicts 'puppet-agent'
-  proj.provides 'puppet-agent', "= #{major}"
+  proj.provides 'puppet-agent', "= #{version}"
 
   proj.timeout 7200 if platform.is_windows?
 end


### PR DESCRIPTION
In the past, our packages had the following provides option:

```

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Provides: puppet-agent (= 8)
```

This is bad, because of weird behaviours in apt.
I thinks 8 isn't the same as 8.0.0.
With this patch, we set the `provides` option to the correct major.minor.patch version, without hardcoding it.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
