### PR TITLE
.gitignore: Ignore /acceptance/.vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ puppet-acceptance/
 /acceptance/junit
 /acceptance/log
 /acceptance/.beaker
+/acceptance/.vendor
 /packaging/acceptance/junit
 /packaging/acceptance/log
 /packaging/acceptance/.beaker


### PR DESCRIPTION
The directory can be created when we run the acceptance tests locally.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
