### PR TITLE
Revert "Add syslog as a runtime dependency"

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('racc', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
-  spec.add_runtime_dependency('syslog', '~> 0.1')
   spec.add_runtime_dependency('win32ole', '>= 1.8', '< 2.0') if Gem.win_platform?
 
   platform = spec.platform.to_s


### PR DESCRIPTION
This reverts commit c1e1111410bdb49c8397f77bc158bc3cf57b216c.

We don't actually need to declare this.

For posterity, the thinking was that failure with JRuby 10 tests at https://github.com/voxpupuli/hiera-eyaml/pull/416 were coming from the syslog feature detection code at https://github.com/OpenVoxProject/openvox/blob/4dd215051e40d0f42c4107417378642b51be99a5/lib/puppet/feature/base.rb#L15 and we needed to declare it here for JRuby 10. But in fact, we had updated CI to test against a newer JRuby 10.0.5.0, which implemented its own syslog implementation that doesn't seem to play nice with this feature detection code.

Including syslog in the gemspec broke Windows, where syslog is not a thing. OpenVox already does the right thing depending on if syslog is available or not. The right thing to do here is remove it from the gemspec. As for warnings that show up on Ruby 3.4/4 around this, we can fix that in another way later.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
