### PR TITLE
Add release version check and stop trying to bump to an RC version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,32 @@ on:
 permissions: {}
 
 jobs:
+  verify-version:
+    name: 'Verify prepare_release PR was merged'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.base-branch }}
+
+      - name: Verify PUPPETVERSION matches release version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          puppetversion=$(ruby -e "require_relative 'lib/puppet/version'; puts Puppet::PUPPETVERSION")
+          if [ "$puppetversion" != "$RELEASE_VERSION" ]; then
+            echo "::error::PUPPETVERSION is '$puppetversion' but expected '$RELEASE_VERSION'. Has the prepare_release PR been merged?"
+            exit 1
+          fi
+          echo "PUPPETVERSION '$puppetversion' matches release version"
+
   release:
+    needs: verify-version
     uses: OpenVoxProject/shared-actions/.github/workflows/release.yml@main
     with:
       version: ${{ inputs.version }}
       base-branch: ${{ inputs.base-branch }}
-      bump_to_rc_after_release: true
     secrets:
       github_pat: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
       ssh_private_key: ${{ secrets.OPENVOXBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This will prevent us from releasing if we forget to merge the PR from prepare_release. This also removes bump_to_rc_after_release since we don't do that in this repo and it would always fail.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
