### PR TITLE
avoid badly anchored regular expression

### DIFF
--- a/lib/puppet/ffi/windows/api_types.rb
+++ b/lib/puppet/ffi/windows/api_types.rb
@@ -230,7 +230,7 @@ module Puppet::FFI::Windows
                :Data4, [:byte, 8]
 
         def self.[](s)
-          raise _('Bad GUID format.') unless s =~ /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i
+          raise _('Bad GUID format.') unless s =~ /\A[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\z/i
 
           new.tap do |guid|
             guid[:Data1] = s[0, 8].to_i(16)

--- a/lib/puppet/interface/action.rb
+++ b/lib/puppet/interface/action.rb
@@ -14,7 +14,7 @@ class Puppet::Interface::Action
 
   # @api private
   def initialize(face, name)
-    raise "#{name.inspect} is an invalid action name" unless name.to_s =~ /^[a-z]\w*$/
+    raise "#{name.inspect} is an invalid action name" unless name.to_s =~ /\A[a-z]\w*\z/
 
     @face    = face
     @name    = name.to_sym


### PR DESCRIPTION
- Ruby documentation: [Anchors](https://ruby-doc.org/3.2.0/Regexp.html#class-Regexp-label-Anchors)
- Common Weakness Enumeration: [CWE-20](https://cwe.mitre.org/data/definitions/20.html)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
