### PR TITLE
Remove source_permissions deprecation warning

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -368,13 +368,7 @@ module Puppet
     defaultto :ignore
     newvalues(:use, :use_when_creating, :ignore)
     munge do |value|
-      value = value ? value.to_sym : :ignore
-      if @resource.file && @resource.line && value != :ignore
-        # TRANSLATORS "source_permissions" is a parameter name and should not be translated
-        Puppet.puppet_deprecation_warning(_("The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`."), file: @resource.file, line: @resource.line)
-      end
-
-      value
+      value ? value.to_sym : :ignore
     end
   end
 end

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1309,21 +1309,6 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
   end
 
   describe "when sourcing" do
-    it "should give a deprecation warning when the user sets source_permissions" do
-      expect(Puppet).to receive(:puppet_deprecation_warning).with(
-        'The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.',
-        {:file => 'my/file.pp', :line => 5})
-
-      catalog.add_resource described_class.new(:path => path, :content => 'this is content', :source_permissions => :use_when_creating)
-      catalog.apply
-    end
-
-    it "should not give a deprecation warning when the user does not set source_permissions" do
-      expect(Puppet).not_to receive(:puppet_deprecation_warning)
-      catalog.add_resource described_class.new(:path => path, :content => 'this is content')
-      catalog.apply
-    end
-
     with_checksum_types "source", "default_values" do
       before(:each) do
         set_mode(0770, checksum_file)

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -165,11 +165,6 @@ describe Puppet::Configurer::Downloader do
       expect(@dler.catalog.host_config).to eq(false)
     end
 
-    it "should not issue a deprecation warning for source_permissions" do
-      expect(Puppet).not_to receive(:puppet_deprecation_warning)
-      catalog = @dler.catalog
-      expect(catalog.resources.size).to eq(1) # Must consume catalog to fix warnings
-    end
   end
 
   describe "when downloading" do


### PR DESCRIPTION
### Short description
The source_permissions parameter is still widely used in the community, so remove the deprecation warning rather than moving toward removal.

Fixes #340.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
