### PR TITLE
Remove filetimeout deprecation warning

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -694,21 +694,8 @@ module Puppet
       :type       => :duration,
       :desc       => "The minimum time to wait between checking for updates in
       configuration files.  This timeout determines how quickly Puppet checks whether
-      a file (such as manifests or puppet.conf) has changed on disk. The default will
-      change in a future release to be 'unlimited', requiring a reload of the Puppet
-      service to pick up changes to its internal configuration. Currently we do not
-      accept a value of 'unlimited'. To reparse files within an environment in
-      Puppet Server please use the environment_cache endpoint",
-      :hook => proc do |val|
-        unless [0, 15, '15s'].include?(val)
-          Puppet.deprecation_warning(<<-WARNING)
-Fine grained control of filetimeouts is deprecated. In future
-releases this value will only determine if file content is cached.
-
-Valid values are 0 (never cache) and 15 (15 second minimum wait time).
-          WARNING
-        end
-      end
+      a file (such as manifests or puppet.conf) has changed on disk. To reparse files
+      within an environment in Puppet Server please use the environment_cache endpoint",
     },
     :environment_timeout => {
       :default    => "0",

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -686,21 +686,8 @@ module Puppet
       :type       => :duration,
       :desc       => "The minimum time to wait between checking for updates in
       configuration files.  This timeout determines how quickly Puppet checks whether
-      a file (such as manifests or puppet.conf) has changed on disk. The default will
-      change in a future release to be 'unlimited', requiring a reload of the Puppet
-      service to pick up changes to its internal configuration. Currently we do not
-      accept a value of 'unlimited'. To reparse files within an environment in
-      Puppet Server please use the environment_cache endpoint",
-      :hook => proc do |val|
-        unless [0, 15, '15s'].include?(val)
-          Puppet.deprecation_warning(<<-WARNING)
-Fine grained control of filetimeouts is deprecated. In future
-releases this value will only determine if file content is cached.
-
-Valid values are 0 (never cache) and 15 (15 second minimum wait time).
-          WARNING
-        end
-      end
+      a file (such as manifests or puppet.conf) has changed on disk. To reparse files
+      within an environment in Puppet Server please use the environment_cache endpoint",
     },
     :environment_timeout => {
       :default    => "0",


### PR DESCRIPTION
### Short description
The filetimeout setting was deprecated in favor of JRuby timers, but since we're moving away from the JVM the fine-grained control is useful again. Remove the deprecation warning and restore full setting semantics.

Fixes #345.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
