### PR TITLE
Modify S3 copy command to suppress progress output

### DIFF
--- a/tasks/upload.rake
+++ b/tasks/upload.rake
@@ -44,7 +44,7 @@ namespace :vox do
     path = "s3://#{bucket}/#{component}/#{args[:tag]}"
     files.each do |f|
       f = `cygpath -m #{f}`.chomp if os =~ /windows/
-      run_command("#{s3} cp #{f} #{path}/#{File.basename(f)}", silent: false)
+      run_command("#{s3} cp #{f} #{path}/#{File.basename(f)} --no-progress", silent: false)
     end
   end
 end


### PR DESCRIPTION
Added --no-progress flag to S3 copy command.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
