### PR TITLE
Update github_changelog_generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ end
 platforms :ruby do
   group :release, optional: true do
     gem 'faraday-retry', require: false
-    gem 'github_changelog_generator', require: false, git: 'https://github.com/voxpupuli/github-changelog-generator', branch: 'avoid-processing-a-single-commit-multiple-time'
+    gem 'github_changelog_generator', '~> 1.18', require: false
   end
 end
 


### PR DESCRIPTION
### Update github_changelog_generator to ~> 1.18

Replace fork/outdated version pins with the released 1.18 gem which
includes the duplicate commit processing fix upstream.