### PR TITLE
Changes to prepare for 8.x branching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ on:
         required: false
         type: boolean
         default: false
+      branch:
+        description: 'The release branch to build from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 jobs:
   build:
@@ -45,6 +52,7 @@ jobs:
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
       working_directory: 'packaging'
+      branch: ${{ inputs.branch }}
     secrets: inherit
   build_dev:
     if: ${{ github.event.inputs.use_dev == 'true' }}
@@ -56,4 +64,5 @@ jobs:
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
       working_directory: 'packaging'
+      branch: ${{ inputs.branch }}
     secrets: inherit

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -8,10 +8,12 @@ on:
         required: true
         type: string
       base-branch:
-        description: 'The branch that will be used as the origin for the release branch.'
-        required: false
-        default: ''
-        type: string
+        description: 'The branch to release from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,12 @@ on:
         required: true
         type: string
       base-branch:
-        description: 'The branch where we do this release.'
-        required: false
-        default: ''
-        type: string
+        description: 'The branch to release from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 permissions: {}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@
 name: RSpec tests
 
 on:
-  pull_request: {}
+  pull_request: { branches: ['main'] }
   push:
     branches:
       - main


### PR DESCRIPTION
Add branch selection to the workflow because we need to pass the branch into the shared build_vanagon so it can look up the right default platforms list. Also convert other base branch inputs to a dropdown for simplicity, and restrict PR testing to the main branch. When we make 8.x, we'll update this to 8.x there so that only main tests run on main PRs and 8.x tests on 8.x PRs.