### PR TITLE
Notify now honors `withpath` parameter

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -11,7 +11,7 @@ module Puppet
 
     newproperty(:message, :idempotent => false) do
       desc "The message to be sent to the log. Note that the value specified must be a string."
-      def sync
+      def insync?(is)
         message = @sensitive ? 'Sensitive [value redacted]' : should
         case @resource["withpath"]
         when :true
@@ -19,15 +19,11 @@ module Puppet
         else
           Puppet.send(@resource[:loglevel], message)
         end
-        nil
+        true
       end
 
       def retrieve
         :absent
-      end
-
-      def insync?(is)
-        false
       end
 
       defaultto { @resource[:name] }


### PR DESCRIPTION
When running Puppet agent with the -t flag, notify resources currently log duplicate messages: one for the explicit message itself, and another for the resource state change (creation/sync). This creates unnecessary log noise, making it harder to spot actual infrastructure changes.

This change modifies the notify resource to always be considered as "existing." By preventing the resource from triggering an out-of-sync event, Puppet will no longer log the redundant state-change notification, resulting in cleaner and more readable execution logs.

The `withpath` parameter now makes sense to be used, since the possible need to actually show the resource path.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
