### PR TITLE
Update ca/crl last_update on HTTP 304 so refresh intervals are respected (#435)

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -121,6 +121,10 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CA certificate is unmodified, using existing CA certificate"))
+        # 304 confirms the local CA is current, so reset the TTL.
+        # Otherwise ca_last_update (backed by ca.pem mtime) never advances
+        # past the initial download and needs_refresh? triggers on every run.
+        @cert_provider.ca_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CA certificate, using existing CA certificate: %{message}") % { message: e.message })
       end
@@ -219,6 +223,8 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CRL is unmodified, using existing CRL"))
+        # 304 confirms the local CRL is current, so reset the TTL.
+        @cert_provider.crl_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CRL, using existing CRL: %{message}") % { message: e.message })
       end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -495,6 +495,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         state.next_state
       end
 
+      it 'updates the `last_update` time on 304 Not Modified so ca_refresh_interval is respected' do
+        stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 304)
+
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:ca_last_update=).with(be_within(60).of(Time.now))
+
+        state.next_state
+      end
+
       it "does not update the `last_update` time when CA refresh fails" do
         stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_raise(Errno::ECONNREFUSED)
 
@@ -653,6 +661,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
       it 'updates the `last_update` time' do
         stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: new_crl_bundle.join)
+
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:crl_last_update=).with(be_within(60).of(Time.now))
+
+        state.next_state
+      end
+
+      it 'updates the `last_update` time on 304 Not Modified so crl_refresh_interval is respected' do
+        stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 304)
 
         expect_any_instance_of(Puppet::X509::CertProvider).to receive(:crl_last_update=).with(be_within(60).of(Time.now))
 


### PR DESCRIPTION
Fixes #435.

When the CA endpoint responds 304 Not Modified, `refresh_ca` previously logged "CA certificate is unmodified" but never reset `ca_last_update`. Since that timestamp is backed by the mtime of `ca.pem`, and the mtime is only bumped on the 200 path through `save_cacerts`, in steady state (where 304 is the typical response) the mtime stayed pinned to the initial download. As a result `needs_refresh?` evaluated to true on every agent run, and the agent issued a conditional GET to the CA every cycle regardless of the configured `ca_refresh_interval`.

`refresh_crl` has the same structural issue but is latent in practice because CRL endpoints return 200 often enough that `save_crls` bumps the mtime naturally. Fixed for symmetry.

Reproduction (from the issue):
```
puppet agent -t --debug 2>&1 | grep -E 'Refreshing CA|unmodified'
```
Prior behavior: logs print on every run. With this patch: logs print at the configured `ca_refresh_interval` (default 24h).

Regression tests added:
- ``updates the `last_update` time on 304 Not Modified so ca_refresh_interval is respected``
- ``updates the `last_update` time on 304 Not Modified so crl_refresh_interval is respected``

Both fail without the patch and pass with it. Full `spec/unit/ssl/state_machine_spec.rb` is green (99 examples).