### PR TITLE
Raise minimum Ruby version to 3.2.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,15 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - {os: ubuntu-24.04, ruby: '3.2'}
           - {os: ubuntu-24.04, ruby: '3.3'}
           - {os: ubuntu-24.04, ruby: '3.4'}
           - {os: ubuntu-24.04, ruby: '4.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.8.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.14.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-10.0.5.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-10.1.0.0'}
-          - {os: windows-2025, ruby: '3.2'}
           - {os: windows-2025, ruby: '3.3'}
           - {os: windows-2025, ruby: '3.4'}
           - {os: windows-2025, ruby: '4.0'}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ plugins:
 
 # without excluding the vendor dirs below, rubocop will load all rubocop config files from installed gems ¯\_(ツ)_/¯
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   Include:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'

--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -2,7 +2,6 @@
 
 require_relative '../../puppet/external/dot'
 require_relative '../../puppet/relationship'
-require 'set'
 
 # A hopefully-faster graph class to replace the use of GRATR.
 class Puppet::Graph::SimpleGraph

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -4,7 +4,6 @@ require_relative '../../puppet/module_tool'
 require_relative '../../puppet/network/format_support'
 require 'uri'
 require_relative '../../puppet/util/json'
-require 'set'
 
 module Puppet::ModuleTool
   # This class provides a data structure representing a module's metadata.

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../../puppet/provider/package'
-require 'set'
 require 'uri'
 
 Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Package do

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require_relative '../../puppet/settings/errors'
 
 # The base setting type

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -5,7 +5,6 @@ require_relative '../puppet/util/tagging'
 require_relative '../puppet/util/skip_tags'
 require_relative '../puppet/application'
 require 'digest/sha1'
-require 'set'
 
 # the class that actually walks our resource/property tree, collects the changes,
 # and performs them

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require_relative '../../puppet/network/format_support'
 
 class Puppet::Util::TagSet < Set

--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
   spec.authors = ["OpenVox Project"]
   spec.date = "2012-08-17"
   spec.description = <<~EOF


### PR DESCRIPTION
### Short description
* Raise the minimum Ruby version to 3.3.0 in `openvox.gemspec`
* Set `TargetRubyVersion` to 3.3 in `.rubocop.yml`
* Fix `rubocop` warnings
* Remove Ruby 3.2 and JRuby 9 from the test matrix

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
