### PR TITLE
acceptance: Fix test failure on Debian 13

### DIFF
--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -27,13 +27,17 @@ agents.each do |agent|
   platform = agent.platform.variant
   init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
 
+  # The /usr merge happened at various points among the Debian distros
   if agent['platform'] =~ /(ubuntu)/
     version = on(agent, facter('os.release.full')).stdout.chomp.to_i
     if version < 24
       init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
     end
   elsif agent['platform'] =~ /debian/
-    init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
+    version = on(agent, facter('os.release.full')).stdout.chomp.to_i
+    if version < 13
+      init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
+    end
   end
 
   symlink_systemd = "/etc/systemd/system/multi-user.target.wants/#{package_name[platform]}.service"


### PR DESCRIPTION
This commit fixes an acceptance test failure on Debian 13 that occurs due to the `/` -> `/usr` "usr merge" landing in that release:

	Failed Tests Cases:
	  Test Case tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb reported: #<Minitest::Assertion:"Expected service symlink to point to systemd init script.\n--- expected\n+++ actual\n@@ -1 +1 @@\n-\"/lib/systemd/system/cron.service\"\n+\"/usr/lib/systemd/system/cron.service\"\n">

This is essentialy the same change as was made for Ubuntu 24.04 in commit c89c20a.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
