### PR TITLE
8.x Backport: Fix rubocop 1.86.2 lint

### DIFF
--- a/lib/puppet/pops/lookup/sub_lookup.rb
+++ b/lib/puppet/pops/lookup/sub_lookup.rb
@@ -21,6 +21,8 @@ module SubLookup
   def split_key(key)
     return [key] if key.match(SPECIAL).nil?
 
+    # Rubocop 1.86.2 starts mis-classifying the "raise yield" constructions as a failure.
+    # rubocop:disable Lint/ParenthesesAsGroupedExpression
     segments = key.split(/(\s*"[^"]+"\s*|\s*'[^']+'\s*|[^'".]+)/)
     if segments.empty?
       # Only happens if the original key was an empty string
@@ -45,6 +47,7 @@ module SubLookup
     else
       raise yield('Syntax error')
     end
+    # rubocop:enable Lint/ParenthesesAsGroupedExpression
   end
 
   # Perform a sub-lookup using the given _segments_ to access the given _value_. Each segment must be a string. A string

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -103,13 +103,13 @@ module Puppet::Util::FileParsing
     # Convert a record into a line by joining the fields together appropriately.
     # This is pulled into a separate method so it can be called by the hooks.
     def join(details)
-      joinchar = self.joiner
+      joinchar = joiner
 
       fields.filter_map { |field|
         # If the field is marked absent, use the appropriate replacement
         if details[field] == :absent or details[field] == [:absent] or details[field].nil?
-          if self.optional.include?(field)
-            self.absent
+          if optional.include?(field)
+            absent
           else
             raise ArgumentError, _("Field '%{field}' is required") % { field: field }
           end


### PR DESCRIPTION
### Short description

This is a backport of PR #447 to the `8.x` branch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
