### PR TITLE
Fix File.open Ruby 3.2 regression in FileSystem::Uniquefile

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -30,21 +30,18 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
   def initialize(basename, *rest)
     create_tmpname(basename, *rest) do |tmpname, _n, opts|
       mode = File::RDWR | File::CREAT | File::EXCL
-      perm = 0o600
       if opts
         mode |= opts.delete(:mode) || 0
-        opts[:perm] = perm
-        perm = nil
+        opts.delete(:perm)
       else
-        opts = perm
+        opts = {}
       end
       self.class.locking(tmpname) do
-        @tmpfile = File.open(tmpname, mode, opts)
+        @tmpfile = File.open(tmpname, mode, 0o600, **opts)
         @tmpname = tmpname
       end
       @mode = mode & ~(File::CREAT | File::EXCL)
-      perm or opts.freeze
-      @opts = opts
+      @opts = opts.freeze
     end
 
     super(@tmpfile)
@@ -53,7 +50,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
   # Opens or reopens the file with mode "r+".
   def open
     @tmpfile.close if @tmpfile
-    @tmpfile = File.open(@tmpname, @mode, @opts)
+    @tmpfile = File.open(@tmpname, @mode, 0o600, **@opts)
     __setobj__(@tmpfile)
   end
 

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -108,6 +108,28 @@ describe Puppet::FileSystem::Uniquefile do
     end
   end
 
+  context "when constructed with an options hash" do
+    after(:each) do
+      @tempfile.close! if @tempfile
+    end
+
+    it "accepts an options hash without raising an error" do
+      expect {
+        @tempfile = Puppet::FileSystem::Uniquefile.new('foo', Dir.tmpdir, mode: 0)
+      }.not_to raise_error
+    end
+
+    it "ensures the file has permissions 0600", unless: Puppet::Util::Platform.windows? do
+      @tempfile = Puppet::FileSystem::Uniquefile.new('foo', Dir.tmpdir, perm: 0o640)
+      expect(Puppet::FileSystem.stat(@tempfile.path).mode & 0o7777).to eq(0o600)
+    end
+
+    it "passes File.open args like :encoding through to the underlying file" do
+      @tempfile = Puppet::FileSystem::Uniquefile.new('foo', Dir.tmpdir, encoding: 'UTF-8')
+      expect(@tempfile.external_encoding.to_s).to eq('UTF-8')
+    end
+  end
+
   context "Ruby 1.9.3 Tempfile tests" do
     # the remaining tests in this file are ported directly from the ruby 1.9.3 source,
     # since most of this file was ported from there


### PR DESCRIPTION
### Short description
Ruby 3.2 changed the method call of File.open() such that it always requires `perm` as an argument if you want to pass other `opts`. It also started requiring opts to be splatted, instead of passed as a hash.

I didn't go through the whole codebase to see if there are other places where this regression (can) happen(s). I just ran into this one when working on an older internal provider that uses `Puppet::FileSystem::Uniquefile.new()` directly (not through the `open_tmp()` method).

Old method definition:
```
open(filename, mode="r" [, opt]) → file
open(filename [, mode [, perm]] [, opt]) → file
open(filename, mode="r" [, opt]) {|file| block } → obj
open(filename [, mode [, perm]] [, opt]) {|file| block } → obj
```

New method definition:
```
open(path, mode = 'r', perm = 0666, **opts) → file
open(path, mode = 'r', perm = 0666, **opts) {|f| ... } → object
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
