### PR TITLE
fix: Pacman provider uses unrecognized option '--update'

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -248,7 +248,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
              else
                fail _("Source %{source} is not supported by pacman") % { source: source }
              end
-    pacman "--noconfirm", "--noprogressbar", "--update", source
+    pacman "--noconfirm", "--noprogressbar", "--upgrade", source
   end
 
   def install_from_repo

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -98,7 +98,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
             resource[:source] = source
 
             expect(executor).to receive(:execute).
-              with(include("--update") & include(source), no_extra_options).
+              with(include("--upgrade") & include(source), no_extra_options).
               ordered.
               and_return("")
 
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
         it "should install from the path segment of the URL" do
           expect(executor).to receive(:execute).
-            with(include("--update") & include(actual_file_path), no_extra_options).
+            with(include("--upgrade") & include(actual_file_path), no_extra_options).
             ordered.
             and_return("")
 


### PR DESCRIPTION
### Short description

In cf789b7a708f51eb6f6d7db1294eaa543b7805c7, long command parameters were introduced for readability. Command argument ``-U`` was changed to ``--update`` but as can be seen in the previous commit's description and below, the actual replacement for this shorthand is ``--upgrade``. With this commit, the correct long form is added.

Examples from command line:

```
[root@host ~]# pacman --update
pacman: unrecognized option '--update'
[root@host ~]# pacman -Uh
usage:  pacman {-U --upgrade} [options] <file(s)>
options:
   ...
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
