### PR TITLE
Add platform definitions for Fedora 44

### DIFF
--- a/packaging/configs/platforms/fedora-44-aarch64.rb
+++ b/packaging/configs/platforms/fedora-44-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'fedora-44-aarch64' do |plat|
+  plat.inherit_from_default
+end

--- a/packaging/configs/platforms/fedora-44-x86_64.rb
+++ b/packaging/configs/platforms/fedora-44-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'fedora-44-x86_64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
This commit adds platform definitions for Fedora 44, both x86_64 and aarch64.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
