### PR TITLE
Decouple :posix feature from :syslog library check

### DIFF
--- a/lib/puppet/feature/base.rb
+++ b/lib/puppet/feature/base.rb
@@ -12,7 +12,7 @@ Puppet.features.add(:syslog, :libs => ["syslog"])
 # We can use POSIX user functions
 Puppet.features.add(:posix) do
   require 'etc'
-  !Etc.getpwuid(0).nil? && Puppet.features.syslog?
+  !Puppet::Util::Platform.windows? && !Etc.getpwuid(0).nil?
 end
 
 # We can use Microsoft Windows functions

--- a/spec/unit/feature/base_spec.rb
+++ b/spec/unit/feature/base_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+require 'puppet/feature/base'
+
+describe "Puppet features" do
+  describe ":posix" do
+    let(:features) { Puppet::Util::Feature.new('puppet/feature') }
+
+    before do
+      features.add(:syslog, :libs => ["syslog"])
+      features.add(:posix) do
+        require 'etc'
+        !Puppet::Util::Platform.windows? && !Etc.getpwuid(0).nil?
+      end
+    end
+
+    it "is true on a non-Windows system where POSIX user functions work" do
+      allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+      allow(Etc).to receive(:getpwuid).with(0).and_return(Etc::Passwd.new('root'))
+
+      expect(features.posix?).to eq(true)
+    end
+
+    it "is false on Windows" do
+      allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
+
+      expect(features.posix?).to eq(false)
+    end
+
+    it "does not invoke Etc.getpwuid on Windows" do
+      allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
+      expect(Etc).not_to receive(:getpwuid)
+
+      features.posix?
+    end
+
+    it "does not depend on the syslog library being loadable" do
+      allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+      allow(Etc).to receive(:getpwuid).with(0).and_return(Etc::Passwd.new('root'))
+      # Simulate syslog gem not being installed.
+      features.add(:syslog, :libs => ["nonexistent-syslog-library-#{SecureRandom.hex(4)}"])
+
+      expect(features.syslog?).to eq(false)
+      expect(features.posix?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
### Short description
The `:posix` feature test required the syslog library to be loadable, but syslog is no longer a default gem in modern Ruby. On a POSIX system without the syslog gem installed, `Puppet.features.posix?` returned `false`, which then caused require of `puppet/feature/base` to `raise "Cannot determine basic system flavour"`.

Detect POSIX by checking that the platform is not Windows and that POSIX user functions (`Etc.getpwuid`) are available. The `:syslog` feature remains for code paths that genuinely need syslog.

Closes #90

(Fix generated by Claude.)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
