### PR TITLE
return to preprocessing deferred functions by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2100,14 +2100,16 @@ EOT
         what is being done.",
     },
     :preprocess_deferred => {
-      :default => false,
+      :default => true,
       :type => :boolean,
       :desc => "Whether Puppet should call deferred functions before applying
         the catalog. If set to `true`, all prerequisites required for the
         deferred function must be satisfied before the Puppet run. If set to
         `false`, deferred functions follow Puppet relationships and
         ordering. In this way, Puppet can install the prerequisites required for a
-        deferred function and call the deferred function in the same run.",
+        deferred function and call the deferred function in the same run.
+        Please note that many functions that return complex datatypes will fail
+        when disabling preprocessing and this option may be removed in the future.",
     },
     :summarize => {
         :default  => false,

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -206,6 +206,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     end
 
     it "applies a deferred function and its prerequisite in the same run" do
+      Puppet[:preprocess_deferred] = false
       catalog_handler = -> (req, res) {
         catalog = compile_to_catalog(deferred_manifest, node)
         res.body = formatter.render(catalog)

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -721,6 +721,7 @@ class amod::bad_type {
     end
 
     it "applies a deferred function and its prerequisite in the same run" do
+      Puppet[:preprocess_deferred] = false
       apply.command_line.args = ['-e', deferred_manifest]
       expect {
         apply.run
@@ -754,6 +755,7 @@ class amod::bad_type {
     end
 
     it "evaluates resources before validating the deferred resource" do
+      Puppet[:preprocess_deferred] = false
       manifest = <<~END
         notify { 'runs before file': } ->
         file { '#{deferred_file}':


### PR DESCRIPTION
In #f939846, the default was changed to evaluate deferred functions
lazily so that any function requirements could be installed during the
same enforcement run. Unfortunately, type of object expected by
parameters is too baked into the entire codebase -- including many third
party type/providers that we have no control over.

This commit changes the default back to preprocessing prior to the
catalog enforcement. Future work is needed in order to handle function
failures more gracefully, which would allow a partial catalog
application to install prerequisistes and a second application to finish
the full configuration enforcement.
