### PR TITLE
Add JRuby 10.0.5.0 and 10.1.0.0 to test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,8 @@ jobs:
           - {os: ubuntu-24.04, ruby: '4.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-9.4.8.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-9.4.14.0'}
+          - {os: ubuntu-24.04, ruby: 'jruby-10.0.5.0'}
+          - {os: ubuntu-24.04, ruby: 'jruby-10.1.0.0'}
           - {os: windows-2025, ruby: '3.2'}
           - {os: windows-2025, ruby: '3.3'}
           - {os: windows-2025, ruby: '3.4'}

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -523,11 +523,12 @@ module Util
 
   module_function :thinmark
 
-  PUPPET_STACK_INSERTION_FRAME = if RUBY_VERSION >= '3.4'
-                                   /.*puppet_stack\.rb.*in.*'Puppet::Pops::PuppetStack\.stack'/
-                                 else
-                                   /.*puppet_stack\.rb.*in.*`stack'/
-                                 end
+  # Matches the frame where Puppet::Pops::PuppetStack.stack appears in a Ruby
+  # backtrace. The format varies by Ruby version and implementation:
+  #   Ruby 3.3:  in `stack'
+  #   Ruby 3.4+: in 'Puppet::Pops::PuppetStack.stack'  (qualified for module method)
+  #   JRuby 10+: in 'stack'                            (unqualified)
+  PUPPET_STACK_INSERTION_FRAME = /puppet_stack\.rb.*in ['`](?:Puppet::Pops::PuppetStack\.)?stack'/
 
   # utility method to get the current call stack and format it to a human-readable string (which some IDEs/editors
   # will recognize as links to the line numbers in the trace)

--- a/spec/integration/agent/logging_spec.rb
+++ b/spec/integration/agent/logging_spec.rb
@@ -37,7 +37,7 @@ require 'puppet/application/agent'
 #
 # Note that this test does not have anything to say about what happens to logging after
 # daemonizing.
-describe 'agent logging' do
+describe 'agent logging', unless: Puppet::Util::Platform.jruby? do
   ONETIME  = '--onetime'
   DAEMONIZE  = '--daemonize'
   NO_DAEMONIZE  = '--no-daemonize'

--- a/spec/integration/util/rdoc/parser_spec.rb
+++ b/spec/integration/util/rdoc/parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'puppet/util/rdoc'
 
-describe "RDoc::Parser", :unless => Puppet::Util::Platform.windows? do
+describe "RDoc::Parser", :unless => Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
   require 'puppet_spec/files'
   include PuppetSpec::Files
 

--- a/spec/unit/util/json_spec.rb
+++ b/spec/unit/util/json_spec.rb
@@ -81,7 +81,7 @@ describe Puppet::Util::Json do
 
     it 'returns nil when the filename is illegal and debug logs about it' do
       expect(Puppet).to receive(:debug)
-        .with(/Could not retrieve JSON content .+: path ?name contains null byte/).and_call_original
+        .with(/Could not retrieve JSON content .+: (?:path ?name|string) contains null byte/).and_call_original
 
       expect(Puppet::Util::Json.load_file_if_valid("not\0allowed")).to eql(nil)
     end

--- a/spec/unit/util/yaml_spec.rb
+++ b/spec/unit/util/yaml_spec.rb
@@ -128,7 +128,7 @@ FACTS
     it 'raises an error when the filename is illegal' do
       expect {
         Puppet::Util::Yaml.safe_load_file("not\0allowed")
-      }.to raise_error(ArgumentError, /path ?name contains null byte/)
+      }.to raise_error(ArgumentError, /(?:path ?name|string) contains null byte/)
     end
 
     it 'raises an error when the file does not exist' do
@@ -156,7 +156,7 @@ FACTS
 
     it 'returns nil when the filename is illegal and debug logs about it' do
       expect(Puppet).to receive(:debug)
-        .with(/Could not retrieve YAML content .+: path ?name contains null byte/).and_call_original
+        .with(/Could not retrieve YAML content .+: (?:path ?name|string) contains null byte/).and_call_original
 
       expect(Puppet::Util::Yaml.safe_load_file_if_valid("not\0allowed")).to eql(nil)
     end


### PR DESCRIPTION
### Short description
Adding JRuby 10 to the test matrix exposed RSpec failures:

* JRuby 10's backtrace format reports module methods unqualified ('stack' instead of 'Puppet::Pops::PuppetStack.stack'), so the PUPPET_STACK_INSERTION_FRAME regex never matched and PuppetStack pseudo-frames stopped being interleaved into log backtraces. Broaden the regex to handle Ruby 3.3 (backtick), Ruby 3.4+ (qualified) and JRuby 10+ (unqualified) formats.
* The integration specs for agent logging and the RDoc parser depend on the syslog and rdoc gems, which are restricted to platforms: [:ruby] in the Gemfile and so are absent on JRuby; skip those describes on JRuby, matching the existing idiom used elsewhere.
* JRuby 10.1.0.0 raises ArgumentError('string contains null byte') instead of MRI's 'path name contains null byte' when a filename contains a NUL; accept either message in the affected json/yaml specs.

Fix generated by Claude.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
