### PR TITLE
8.x Backport: Fix Debian 13 acceptance tests

### DIFF
--- a/acceptance/lib/puppet/acceptance/i18ndemo_utils.rb
+++ b/acceptance/lib/puppet/acceptance/i18ndemo_utils.rb
@@ -8,18 +8,37 @@ module Acceptance
     I18NDEMO_NAME = "i18ndemo"
     I18NDEMO_MODULE_NAME = "eputnam-#{I18NDEMO_NAME}"
 
+    # Returns the command line to set system LANG for the given host.
+    #
+    # Debian-family platforms use update-locale (from the 'locales' package),
+    # which writes /etc/default/locale directly. We avoid localectl there
+    # because it routes through systemd-localed/polkit; starting with Debian 13
+    # (trixie) that path denies Beaker's non-interactive SSH session with
+    # "Failed to issue method call: Access denied". This change is expected
+    # to filter down to Ubuntu and other Debian-based distros.
+    #
+    # Every other platform keeps using localectl, which works under their
+    # default polkit policy.
+    def set_system_locale_command(host, language)
+      if %w[debian ubuntu].include?(host['platform'].variant)
+        "update-locale LANG=#{language}"
+      else
+        "localectl set-locale LANG=#{language}"
+      end
+    end
+
     def configure_master_system_locale(requested_language)
       language = enable_locale_language(master, requested_language)
       fail_test("puppet server machine is missing #{requested_language} locale. help...") if language.nil?
 
-      on(master, "localectl set-locale LANG=#{language}")
+      on(master, set_system_locale_command(master, language))
       on(master, puppet_resource('service', master['puppetservice'], 'ensure=stopped'))
       on(master, puppet_resource('service', master['puppetservice'], 'ensure=running'))
     end
 
     def reset_master_system_locale
       language = enable_locale_language(master, 'en_US')
-      on(master, "localectl set-locale LANG=#{language}")
+      on(master, set_system_locale_command(master, language))
       on(master, puppet_resource('service', master['puppetservice'], 'ensure=stopped'))
       on(master, puppet_resource('service', master['puppetservice'], 'ensure=running'))
     end

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -27,13 +27,17 @@ agents.each do |agent|
   platform = agent.platform.variant
   init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
 
+  # The /usr merge happened at various points among the Debian distros
   if agent['platform'] =~ /(ubuntu)/
     version = on(agent, facter('os.release.full')).stdout.chomp.to_i
     if version < 24
       init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
     end
   elsif agent['platform'] =~ /debian/
-    init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
+    version = on(agent, facter('os.release.full')).stdout.chomp.to_i
+    if version < 13
+      init_script_systemd = "/lib/systemd/system/#{package_name[platform]}.service"
+    end
   end
 
   symlink_systemd = "/etc/systemd/system/multi-user.target.wants/#{package_name[platform]}.service"


### PR DESCRIPTION
### Short description

This is a 8.x backport of the following changes to the `main` branch: #444 and #464 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
