### PR TITLE
Readd workflow to backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,23 @@
+---
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [labeled]
+permissions:
+  contents: write      # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport merged pull request
+    runs-on: ubuntu-latest
+    # For security reasons, we don't want to checkout and run arbitrary code when
+    # using the pull_request_target trigger. So restrict this to cases where the
+    # backport label is applied to an already merged PR.
+    if: github.event.pull_request.merged && contains(github.event.label.name, 'backport')
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Create backport pull requests
+        uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
+        with:
+          auto_merge_enabled: true
+          auto_merge_method: merge


### PR DESCRIPTION
We used this previously to backport changes to the 7.x branch. We can use it again for the 8.x branch. If a PR gets the backport 8.x label and gets merged, the commit(s) will be cherry-picked and provided as a new PR, to the 8.x branch.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
