### PR TITLE
Add windows-msys2-x64 build for OpenVox 9

### DIFF
--- a/packaging/configs/components/cleanup.rb
+++ b/packaging/configs/components/cleanup.rb
@@ -24,12 +24,6 @@ component "cleanup" do |pkg, settings, platform|
       "#{rm} -rf #{settings[:prefix]}/ssl/man",
     ]
 
-    if platform.is_windows?
-      # On Windows releases that distribute curl, these curl binaries can
-      # interfere with the native ones when puppet-agent's bindir is in the PATH:
-      cleanup_steps << "#{rm} #{settings[:bindir]}/curl*"
-    end
-
     cleanup_steps << "#{rm} -rf #{settings[:service_conf]}"
 
     pkg.install { cleanup_steps }

--- a/packaging/configs/components/openssl-fips.rb
+++ b/packaging/configs/components/openssl-fips.rb
@@ -29,7 +29,7 @@ component "openssl-fips" do |pkg, settings, platform|
   # into place after `fipsmodule.cnf` is generated. So ship `openssl-fips.cnf`
   # and rename it to `openssl.cnf` during postinstall action.
   #
-  extract_dir = platform.is_windows? ? '/cygdrive/c' : '/'
+  extract_dir = platform.is_windows? ? '/c' : '/'
   pkg.install do
     [
       "#{platform.tar} --skip-old-files --directory=#{extract_dir} --extract --gunzip --file=#{tarball_name}",

--- a/packaging/configs/components/puppet-runtime.rb
+++ b/packaging/configs/components/puppet-runtime.rb
@@ -43,8 +43,8 @@ component 'puppet-runtime' do |pkg, settings, platform|
     # ... weird, and we need to be able to use cygwin environment variable use
     # so cmd.exe was not working as expected.
     install_command = [
-      "gunzip -c #{tarball_name} | tar -k -C /cygdrive/c/ -xf -",
-      "chmod 755 #{settings[:bindir].sub('C:', '/cygdrive/c')}/*"
+      "gunzip -c #{tarball_name} | tar -k -C /c/ -xf -",
+      "chmod 755 #{settings[:bindir].sub('C:', '/c')}/*"
     ]
   elsif platform.is_macos?
     # We can't untar into '/' because of SIP on macOS; Just copy the contents

--- a/packaging/configs/platforms/windows-msys2-x64.rb
+++ b/packaging/configs/platforms/windows-msys2-x64.rb
@@ -1,0 +1,3 @@
+platform 'windows-msys2-x64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
### Short description

This patch set updates the build logic for `openvox-agent` to use a new windows-msys2-x64 platform to build the Ruby 4 runtime under MSYS2 + MINGW-w64-UCRT. The older Cygwin + MINGW build is retained for building agent-runtime-8.x against MSVCRT.

Switching to UCRT is required as upstream Ruby 3.1 migrated to using this C runtime and Ruby 4.0 no longer builds against the older MSVCRT. Besides fixing the build, using the same x64-mingw-ucrt architecture as upstream Ruby allows pre-compiled Rubygems, e.g. nokogiri, to be installed without requiring Windows nodes to have a C compiler and other devtools installed.

Depends on related changes in OpenVoxProject/puppet-runtime#199.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
