### PR TITLE
Backport: Bump Beaker dependency to ~>6.8

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.8')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION' || "~> 4.0"])
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1.0")

--- a/packaging/acceptance/Gemfile
+++ b/packaging/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 6")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 6.8")
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1")


### PR DESCRIPTION
This commit updates the Beaker pin from `~>6.0` to `~>6.8` which forces dependency resolution to pick up a fix that prevents Beaker from mis-classifying `el-10` as `el-1` and falling back to SysV service management commands:

  voxpupuli/beaker@400af53c2


(cherry picked from commit 4632ad7291912ea2d4feda2d62b2d29e3fce8fbd)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
