### PR TITLE
Manage group members on EL 10 without libuser

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -19,10 +19,14 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   optional_commands :localadd => "lgroupadd", :localdelete => "lgroupdel", :localmodify => "lgroupmod", :purgemember => "usermod"
 
-  has_feature :manages_local_users_and_groups if Puppet.features.libuser?
-  has_feature :manages_members if Puppet.features.libuser? ||
-                                  (Puppet.runtime[:facter].value('os.name') == "Fedora" &&
-                                  Puppet.runtime[:facter].value('os.release.major').to_i >= 40)
+  if Puppet.features.libuser?
+    has_feature :manages_local_users_and_groups
+    has_feature :manages_members
+  elsif Puppet.runtime[:facter].value('os.name') == "Fedora"
+    has_feature :manages_members if Puppet.runtime[:facter].value('os.release.major').to_i >= 40
+  elsif Puppet.runtime[:facter].value('os.family') == "RedHat"
+    has_feature :manages_members if Puppet.runtime[:facter].value('os.release.major').to_i >= 10
+  end
 
   # Libuser's modify command 'lgroupmod' requires '-M' flag for member additions.
   # 'groupmod' command requires the '-aU' flags for it.


### PR DESCRIPTION
### Short description

Commit 6a1db9e53b7 updated the `groupadd` provider to account for the deprecation of `libuser` in Fedora 40. EL 10 is downstream of Fedora 40 and while the `libuser` package is available, some distros do not install it by default. When the `libuser` package is missing, catalog application will silently ignore the `members` attribute of `group` resources.

This commit re-factors the logic of the `groupadd` provider to enable the `manages_members` feature when `os.family == RedHat` and `os.release.major >=10` for non-Fedora distros.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
