### PR TITLE
Fix regex node lookup regression from PUP-11515

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -34,13 +34,13 @@ class Puppet::Resource::Type
   EMPTY_ARRAY = [].freeze
 
   LOOKAROUND_OPERATORS = {
-    "(" => 'LP',
-    "?" => "QU",
-    "<" => "LT",
-    ">" => "GT",
-    "!" => "EX",
-    "=" => "EQ",
-    ")" => 'RP'
+    "(" => 'lp',
+    "?" => "qu",
+    "<" => "lt",
+    ">" => "gt",
+    "!" => "ex",
+    "=" => "eq",
+    ")" => 'rp'
   }.freeze
 
   attr_accessor :file, :line, :doc, :code, :parent, :resource_type_collection, :override
@@ -206,7 +206,7 @@ class Puppet::Resource::Type
 
   def name
     if type == :node && name_is_regex?
-      # Normalize lookarround regex patthern
+      # Normalize lookaround regex pattern to a unique, lookup-safe lowercase string.
       internal_name = @name.source.downcase.gsub(/\(\?[^)]*\)/) do |str|
         str.gsub(/./) { |ch| LOOKAROUND_OPERATORS[ch] || ch }
       end

--- a/spec/integration/parser/node_spec.rb
+++ b/spec/integration/parser/node_spec.rb
@@ -85,7 +85,7 @@ describe 'node statements' do
       end.not_to raise_error
     end
 
-    it 'does not raise an error with 2 regex node names are the same due to lookarround pattern' do
+    it 'does not raise an error with 2 regex node names are the same due to lookaround pattern' do
       expect do
         compile_to_catalog(<<-MANIFEST, Puppet::Node.new("async"))
         node /(?<!a)sync/ { }
@@ -101,6 +101,63 @@ describe 'node statements' do
         node /a.*c/ { }
         MANIFEST
       end.to raise_error(Puppet::Error, /Node '__node_regexp__a.c' is already defined/)
+    end
+
+    # Regression test for https://github.com/OpenVoxProject/openvox/issues/14
+    # A regex with non-capturing group syntax (?:...) or other lookaround constructs
+    # caused uppercase characters to appear in the synthetic node key, which is stored
+    # in the TypeCollection hash.  Lookups always downcase the key via munge_name(), so
+    # the node could never be found again, producing "Cannot find definition Node".
+    it 'matches a node whose regex contains a non-capturing group' do
+      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("thing-foo-42"))
+      node /^thing-(foo|bar)(?:-test)?-(\\d+)$/ { notify { matched: } }
+      node default                              { notify { unmatched: } }
+      MANIFEST
+
+      expect(catalog).not_to have_resource('Notify[unmatched]')
+      expect(catalog).to have_resource('Notify[matched]')
+    end
+
+    it 'matches a node whose regex contains a non-capturing group for the optional suffix' do
+      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("thing-bar-test-7"))
+      node /^thing-(foo|bar)(?:-test)?-(\\d+)$/ { notify { matched: } }
+      node default                              { notify { unmatched: } }
+      MANIFEST
+
+      expect(catalog).not_to have_resource('Notify[unmatched]')
+      expect(catalog).to have_resource('Notify[matched]')
+    end
+
+    it 'does not match a node when the non-capturing-group regex prefix does not match' do
+      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("thing-baz-7"))
+      node /^thing-(foo|bar)(?:-test)?-(\\d+)$/ { notify { matched: } }
+      node default                              { notify { unmatched: } }
+      MANIFEST
+
+      expect(catalog).not_to have_resource('Notify[matched]')
+      expect(catalog).to have_resource('Notify[unmatched]')
+    end
+
+    it 'matches a node whose regex contains a negative lookahead' do
+      # /^(db01)\.(?!hosts).*$/ matches db01.<anything-except-hosts...>
+      # e.g. db01.example.com matches, db01.hosts.example.com does not
+      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("db01.example.com"))
+      node /^(db01)\.(?!hosts).*$/ { notify { matched: } }
+      node default                 { notify { unmatched: } }
+      MANIFEST
+
+      expect(catalog).not_to have_resource('Notify[unmatched]')
+      expect(catalog).to have_resource('Notify[matched]')
+    end
+
+    it 'does not match a node excluded by a negative lookahead' do
+      catalog = compile_to_catalog(<<-MANIFEST, Puppet::Node.new("db01.hosts.example.com"))
+      node /^(db01)\.(?!hosts).*$/ { notify { matched: } }
+      node default                 { notify { unmatched: } }
+      MANIFEST
+
+      expect(catalog).not_to have_resource('Notify[matched]')
+      expect(catalog).to     have_resource('Notify[unmatched]')
     end
 
     it 'provides captures from the regex in the node body' do

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -67,6 +67,21 @@ describe Puppet::Resource::Type do
         expect(Puppet::Resource::Type.new(:node, /W/).name).to eq("__node_regexp__w")
       end
 
+      # Regression coverage for issue #14: lookaround syntax must be encoded into a
+      # lowercase synthetic name so node lookups can find the stored regex node again.
+      it "should normalize lookaround syntax into a lowercase synthetic name" do
+        expect(Puppet::Resource::Type.new(:node, /(?<!a)sync/).name).to eq("__node_regexp__lpqultexarpsync")
+      end
+
+      it "should keep lookaround names distinct from otherwise similar regexes" do
+        lookaround = Puppet::Resource::Type.new(:node, /(?<!a)sync/).name
+        plain = Puppet::Resource::Type.new(:node, /async/).name
+
+        expect(lookaround).not_to eq(plain)
+        expect(lookaround).to eq(lookaround.downcase)
+        expect(plain).to eq(plain.downcase)
+      end
+
       it "should remove non-alpha characters when returning the name as a string" do
         expect(Puppet::Resource::Type.new(:node, /w*w/).name).not_to include("*")
       end


### PR DESCRIPTION
### Short description
The LOOKAROUND_OPERATORS tokens introduced in 5d09d7f are uppercase, but TypeCollection#munge_name() lowercases all lookup keys, so regex nodes with group syntax (e.g. (?:-test)) were stored under a key that could never be found again, producing "Cannot find definition Node".

Fix: use downcased lookaround operators.

Fixes: https://github.com/OpenVoxProject/openvox/issues/14

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
