### PR TITLE
Fix "translates custom oids to their long name" test

### DIFF
--- a/spec/integration/application/ssl_spec.rb
+++ b/spec/integration/application/ssl_spec.rb
@@ -4,9 +4,12 @@ describe "puppet ssl", unless: Puppet::Util::Platform.jruby? do
   context "print" do
     it 'translates custom oids to their long name' do
       basedir = File.expand_path("#{__FILE__}/../../../fixtures/ssl")
+      puppet = File.expand_path("#{__FILE__}/../../../../bin/puppet")
+      libdir = File.expand_path("#{__FILE__}/../../../../lib")
+      ruby = Puppet::Util::Execution.ruby_path
       # registering custom oids changes global state, so shell out
       output =
-        %x{puppet ssl show \
+        %x{#{ruby} -I#{libdir} #{puppet} ssl show \
            --certname oid \
            --localcacert #{basedir}/ca.pem \
            --hostcrl #{basedir}/crl.pem \


### PR DESCRIPTION
Previously, this test used puppet from $PATH on Linux, and if you ran the test suite in a git repo, it would accidentally test the puppet version that was already installed on the system (rather than the one you are actively working on), and the test would fail if puppet was not installed.

I fixed the test to use a relative puppet path, so that we aren't getting accidentaly pass/fail from the wrong binary.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [X] added or modified unit test(s)
