### PR TITLE
Fix CA/CRL refresh retriggering every run on 304

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -121,6 +121,7 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CA certificate is unmodified, using existing CA certificate"))
+        @cert_provider.ca_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CA certificate, using existing CA certificate: %{message}") % { message: e.message })
       end
@@ -219,6 +220,7 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CRL is unmodified, using existing CRL"))
+        @cert_provider.crl_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CRL, using existing CRL: %{message}") % { message: e.message })
       end


### PR DESCRIPTION
When the server responds with 304 Not Modified, ca_last_update and crl_last_update were not updated. Since these read the mtime of the CA cert / CRL file on disk, the stale timestamp caused needs_refresh? to return true on every subsequent run, ignoring ca_refresh_interval and crl_refresh_interval.

Fix by updating the timestamp on 304 so the interval is respected.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
