### PR TITLE
Add arm64 support to acceptance

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,7 +1,8 @@
 ---
 name: Beaker OpenVox Acceptance Tests
 run-name: |-
-  Beaker acceptance tests of openvox for
+  Beaker acceptance tests of openvox
+  on ${{ inputs.guest-arch }} runners for
   ${{ inputs.pre-release-build && 'pre-release' || 'release' }}
   packages of openvox-agent
   ${{ (inputs.pre-release-build && inputs.openvox-agent-version) ||
@@ -80,6 +81,20 @@ on:
           true)
         default: 'https://s3.osuosl.org/openvox-artifacts'
         type: string
+      guest-arch:
+        description: |-
+          The architecture of the guest VMs to run the acceptance tests
+          on. This is used by the nested_vms action to determine which
+          VM images to use.
+
+          If not provided, the default is x86_64.
+
+          NOTE: Currently only x86_64 *runners* support nested
+          virtualization, so if guest-arch is set to arm64, the
+          nested_vms will run under qemu and be quite a bit slower
+          (5x-20x).
+        type: string
+        default: 'x86_64'
 
 permissions:
   contents: read
@@ -103,3 +118,4 @@ jobs:
       openvox-server-version: ${{ inputs.openvox-server-version }}
       openvox-server-pre-release-build: ${{ inputs.pre-release-build }}
       artifacts-url: ${{ inputs.artifacts-url }}
+      guest-arch: ${{ inputs.guest-arch }}

--- a/acceptance/pre-suite/010_set_puppetserver_memory_defaults.rb
+++ b/acceptance/pre-suite/010_set_puppetserver_memory_defaults.rb
@@ -12,7 +12,13 @@ test_name 'Set Puppetserver Memory Defaults' do
                  end
 
   if half_mem > 2048
-    on(master, "sed -i -E -e '/^JAVA_ARGS=/ s/-Xms[0-9]+[m|g] -Xmx[0-9]+[m|g]/-Xms#{half_mem}m -Xmx#{half_mem}m/' #{defaults_dir}/puppetserver")
+    mem_regex       = "-Xms[0-9]+[m|g][[:blank:]]+-Xmx[0-9]+[m|g]"
+    mem_replacement = "-Xms#{half_mem}m -Xmx#{half_mem}m"
+    on(master, <<~EOS)
+      sed -i -E \
+        -e '/^JAVA_ARGS=/ s/#{mem_regex}/#{mem_replacement}/' \
+        #{defaults_dir}/puppetserver
+    EOS
     on(master, "cat #{defaults_dir}/puppetserver")
   else
     logger.info("System memory on the primary is less than 4GB (#{(mem_in_bytes.to_i / megabytes)}m). Leaving the defult 2GB for Puppetserver memory.")

--- a/acceptance/pre-suite/011_set_puppetserver_timeouts.rb
+++ b/acceptance/pre-suite/011_set_puppetserver_timeouts.rb
@@ -1,0 +1,34 @@
+test_name 'Set Puppetserver start and reload timeouts' do
+  skip_test 'No primary node to configure Puppetserver timeouts for' unless master
+
+  start_timeout = options['puppetserver-start-timeout']
+  reload_timeout = options['puppetserver-reload-timeout']
+  skip_test 'No timeout options specified, skipping' if (start_timeout.nil? && reload_timeout.nil?)
+
+  # Update the defaults used internally by the puppetserver
+  # service scripts.
+  defaults_dir = case master.platform
+                 when /debian|ubuntu/ then  '/etc/default'
+                 else '/etc/sysconfig'
+                 end
+
+  exprs = []
+  exprs <<  "-e '/^START_TIMEOUT=/ s/=.*$/=#{start_timeout}/'" if !start_timeout.nil?
+  exprs <<  "-e '/^RELOAD_TIMEOUT=/ s/=.*$/=#{reload_timeout}/'" if !reload_timeout.nil?
+  on(master, "sed -i #{exprs.join(' ')} #{defaults_dir}/puppetserver")
+  on(master, "cat #{defaults_dir}/puppetserver")
+
+  # And update the defaults used by the systemd service unit.
+  # Puppetserver will effectively timeout a start at whichever
+  # is shorter...
+  if !start_timeout.nil?
+    dropin_dir = '/etc/systemd/system/puppetserver.service.d'
+    on(master, <<~EOS)
+      mkdir -p #{dropin_dir}
+      printf '[Service]\\nTimeoutStartSec=#{start_timeout}\\n' \
+        > #{dropin_dir}/timeouts.conf
+    EOS
+    on(master, 'systemctl daemon-reload')
+    on(master, 'systemctl cat puppetserver.service')
+  end
+end

--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -3,7 +3,8 @@ tag 'audit:integration', # lockfile uses the standard `vardir` location to store
                          # The validation of the `vardir` at the OS level
                          # should be accomplished in another test.
     'audit:high',
-    'audit:refactor'     # This test should not require a master. Remove the use of `with_puppet_running_on`.
+    'audit:refactor',    # This test should not require a master. Remove the use of `with_puppet_running_on`.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 #
 # This test is intended to ensure that puppet agent --enable/--disable

--- a/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
+++ b/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
@@ -1,6 +1,7 @@
 test_name "agent run should fail if it finds an unknown resource type" do
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
 

--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -4,7 +4,8 @@ tag 'risk:high',
     'audit:high',        # tests defined catalog format
     'audit:integration', # There is no OS specific risk here.
     'server',
-    'catalog:json'
+    'catalog:json',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/common_utils'
 require 'json'

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -2,7 +2,8 @@ test_name "fallback to the cached catalog"
 
 tag 'audit:high',
     'audit:integration', # This test is not OS sensitive.
-    'audit:refactor'     # A catalog fixture can be used for this test. Remove the usage of `with_puppet_running_on`.
+    'audit:refactor',    # A catalog fixture can be used for this test. Remove the usage of `with_puppet_running_on`.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 step "run agents once to cache the catalog" do
   with_puppet_running_on master, {} do

--- a/acceptance/tests/agent/last_run_summary_report.rb
+++ b/acceptance/tests/agent/last_run_summary_report.rb
@@ -1,5 +1,6 @@
 test_name "The 'last_run_summary.yaml' report has the right location and permissions" do
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/temp_file_utils'
   extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,7 +1,8 @@
 test_name "aix package provider should work correctly" do
 
   tag 'audit:high',
-      'audit:acceptance'  # OS specific by definition.
+      'audit:acceptance', # OS specific by definition.
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   confine :to, :platform => /aix/
 

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,7 +1,8 @@
 test_name "NIM package provider should work correctly"
 
 tag 'audit:high',
-    'audit:acceptance'  # OS specific by definition
+    'audit:acceptance', # OS specific by definition
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 # nim test is slow, confine to only aix 7.2 and recent puppet versions
 confine :to, :platform => "aix" do |aix|

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -3,7 +3,8 @@ test_name "node_name_fact should be used to determine the node name for puppet a
 tag 'audit:high',
     'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
                           # Testing of passenger master is no longer needed.
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 success_message = "node_name_fact setting was correctly used to determine the node name"
 

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -3,7 +3,8 @@ test_name "node_name_value should be used as the node name for puppet agent"
 tag 'audit:high',
     'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
                           # Testing of passenger master is no longer needed.
-    'server'
+    'server',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 success_message = "node_name_value setting was correctly used as the node name"
 testdir = master.tmpdir('nodenamevalue')

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -1,7 +1,8 @@
 test_name "parametrized classes"
 
 tag 'audit:high',
-    'audit:unit'   # This should be covered at the unit layer.
+    'audit:unit',  # This should be covered at the unit layer.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 ########################################################################
 step "should allow param classes"

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -1,7 +1,8 @@
 test_name "should allow param override"
 
 tag 'audit:high',
-    'audit:unit'   # This should be covered at the unit layer.
+    'audit:unit',  # This should be covered at the unit layer.
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 manifest = %q{
 class parent {

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -1,7 +1,8 @@
 test_name "should allow overriding a parameter to undef in inheritence"
 
 tag 'audit:high',
-    'audit:unit'   # This should be covered at the unit layer.
+    'audit:unit',  # This should be covered at the unit layer.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   dir = agent.tmpdir('class_undef_override')

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -1,7 +1,8 @@
 test_name "resources declared in a class can be applied with include"
 
 tag 'audit:high',
-    'audit:unit'   # This should be covered at the unit layer.
+    'audit:unit',  # This should be covered at the unit layer.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 manifest = %q{
 class x {

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -1,7 +1,8 @@
 test_name "resources declared in classes are not applied without include"
 
 tag 'audit:high',
-    'audit:unit'   # This should be covered at the unit layer.
+    'audit:unit',  # This should be covered at the unit layer.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
 apply_manifest_on(agents, manifest) do |result|

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -7,7 +7,8 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   extend Puppet::Acceptance::AgentFqdnUtils
 
   tag 'risk:high',
-      'server'
+      'server',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   test_num        = 'c100300'
   tmp_environment = mk_tmp_environment_with_teardown(master, File.basename(__FILE__, '.*'))

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -6,7 +6,8 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
   tag 'audit:high',
       'audit:acceptance',
       'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
 
   skip_test 'requires puppetserver installation' if @options[:type] != 'aio'

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -2,8 +2,9 @@ test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
 
   tag 'audit:high',
       'audit:acceptance',
-      'audit:refactor'    # remove dependence on server by adding a
+      'audit:refactor',   # remove dependence on server by adding a
                           # catalog and report fixture to validate against.
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -3,7 +3,8 @@ test_name "Environment control of static catalogs"
 tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 skip_test 'requires puppetserver to test static catalogs' if @options[:type] != 'aio'
 

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -8,7 +8,8 @@ test_name "C97172: static catalogs support utf8" do
 
   tag 'audit:high',
       'audit:acceptance',
-      'audit:refactor'  # Review for agent side UTF validation.
+      'audit:refactor', # Review for agent side UTF validation.
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   app_type = File.basename(__FILE__, '.*')
   tmp_environment   = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -3,7 +3,8 @@ test_name 'PUP-3755 Test an un-assigned broken environment'
 tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # Use mk_tmp_environment_with_teardown helper
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 teardown do
   agents.each do |agent|

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -2,7 +2,8 @@ test_name "Can enumerate environments via an HTTP endpoint"
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 confine :except, :platform => /osx/ # see PUP-4820
 

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -4,7 +4,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 
 tag 'audit:high',
     'audit:integration',  # This behavior is specific to the master to 'do the right thing'
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -2,7 +2,8 @@ test_name 'ensure production environment created by master if missing'
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 testdir = create_tmpdir_for_user master, 'prod-env-created'
 

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -4,7 +4,8 @@ test_name "Master should produce error if enc specifies a nonexistent environmen
 
   tag 'audit:high',
       'audit:unit',
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -7,7 +7,8 @@ test_name 'Test behavior of directory environments when environmentpath is set t
   tag 'audit:high',
       'audit:unit', # The error responses for the agent should be covered by Ruby unit tests.
       # The server 404/400 response should be covered by server integration tests.
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/environment/feature_branch_configured_environment.rb
+++ b/acceptance/tests/environment/feature_branch_configured_environment.rb
@@ -3,7 +3,8 @@ test_name "Agent should use set environment after running with specified environ
   extend Puppet::Acceptance::EnvironmentUtils
 
   tag 'audit:high',
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/should_find_existing_production_environment.rb
+++ b/acceptance/tests/environment/should_find_existing_production_environment.rb
@@ -1,5 +1,6 @@
 test_name "should find existing production environment"
-tag 'audit:medium'
+tag 'audit:medium',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/i18ndemo_utils'
 extend Puppet::Acceptance::I18nDemoUtils

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -4,7 +4,8 @@ test_name "Agent should use agent environment if there is an enc that does not s
 
   tag 'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -3,7 +3,8 @@ test_name "Agent should use agent environment if there is no enc-specified envir
   tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This can be combined with use_agent_environment_when_enc_doesnt_specify test
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -4,7 +4,8 @@ test_name 'Agent should use environment given by ENC and only compile a catalog 
 
   tag 'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/use_enc_environment_for_files.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_files.rb
@@ -3,7 +3,8 @@ test_name "Agent should use environment given by ENC for fetching remote files" 
   tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This test should be rolled into use_enc_environment
-      'server'
+      'server',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -3,7 +3,8 @@ test_name "Agent should use environment given by ENC for pluginsync" do
   tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This test should be rolled into use_enc_environment
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -4,7 +4,8 @@ test_name "Use environments from the environmentpath" do
 
   tag 'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   classify_nodes_as_agent_specified_if_classifer_present
 

--- a/acceptance/tests/environment/use_last_server_specified_environment.rb
+++ b/acceptance/tests/environment/use_last_server_specified_environment.rb
@@ -3,7 +3,8 @@ test_name "Agent should use the last server-specified environment if server is a
   extend Puppet::Acceptance::EnvironmentUtils
 
   tag 'audit:high',
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -6,7 +6,8 @@ test_name 'C98115 compilation should get new values in variables on each compila
 
   tag 'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,9 +1,11 @@
 test_name "Puppet facts face should resolve custom and external facts"
 
 tag 'audit:high',
-    'audit:integration'   # The facter acceptance tests should be acceptance.
+    'audit:integration',  # The facter acceptance tests should be acceptance.
                           # However, the puppet face merely needs to interact with libfacter.
                           # So, this should be an integration test.
+    'shard:group4' # For splitting out groups of tests for slow test runners
+
 #
 # This test is intended to ensure that custom and external facts present
 # on the agent are resolved and displayed by the puppet facts face.

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -5,8 +5,9 @@ confine :except, :platform => 'windows'
 
 tag 'audit:high',
     'audit:acceptance',    # This has been OS sensitive.
-    'audit:refactor'       # Remove the confine against windows and refactor to
+    'audit:refactor',      # Remove the confine against windows and refactor to
                            # accommodate the Windows platform.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,8 +1,9 @@
 test_name 'parser validate' do
 
 tag 'audit:high',
-    'audit:unit'   # Parser validation should be core to ruby
+    'audit:unit',  # Parser validation should be core to ruby
                    # and platform agnostic.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/i18n/enable_option_disable_i18n.rb
+++ b/acceptance/tests/i18n/enable_option_disable_i18n.rb
@@ -2,7 +2,8 @@ test_name 'Verify that disable_i18n can be set to true and have translations dis
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -2,7 +2,8 @@ test_name 'C100565: puppet agent with module should translate messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')
   # function validate_absolute_path used https://github.com/eputnam/eputnam-i18ndemo/blob/621d06d/manifests/init.pp#L15

--- a/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
@@ -2,7 +2,8 @@ test_name 'C100566: puppet agent with module should translate messages when usin
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')
   # function validate_absolute_path used https://github.com/eputnam/eputnam-i18ndemo/blob/621d06d/manifests/init.pp#L15

--- a/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
@@ -2,7 +2,8 @@ test_name 'C100575: puppet agent with different modules in different environment
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/i18n/modules/puppet_apply.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply.rb
@@ -2,7 +2,8 @@ test_name 'C100567: puppet apply of module should translate messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')
   # function validate_absolute_path used https://github.com/eputnam/eputnam-i18ndemo/blob/621d06d/manifests/init.pp#L15

--- a/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_module_lang.rb
@@ -3,7 +3,8 @@ test_name 'C100574: puppet apply using a module should translate messages in a l
   confine :except, :platform => /^windows/ # Can't print Finish on an English or Japanese code page
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')
   # function validate_absolute_path used https://github.com/eputnam/eputnam-i18ndemo/blob/621d06d/manifests/init.pp#L15

--- a/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
+++ b/acceptance/tests/i18n/modules/puppet_apply_unsupported_lang.rb
@@ -1,7 +1,8 @@
 test_name 'C100568: puppet apply of module for an unsupported language should fall back to english' do
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')
   # function validate_absolute_path used https://github.com/eputnam/eputnam-i18ndemo/blob/621d06d/manifests/init.pp#L15

--- a/acceptance/tests/i18n/modules/puppet_describe.rb
+++ b/acceptance/tests/i18n/modules/puppet_describe.rb
@@ -2,7 +2,8 @@ test_name 'C100576: puppet describe with module type translates message' do
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/i18n_utils'
   extend Puppet::Acceptance::I18nUtils

--- a/acceptance/tests/i18n/modules/puppet_face.rb
+++ b/acceptance/tests/i18n/modules/puppet_face.rb
@@ -2,7 +2,8 @@ test_name 'C100573: puppet application/face with module translates messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/i18n_utils'
   extend Puppet::Acceptance::I18nUtils

--- a/acceptance/tests/i18n/modules/puppet_resource.rb
+++ b/acceptance/tests/i18n/modules/puppet_resource.rb
@@ -2,7 +2,8 @@ test_name 'C100572: puppet resource with module translates messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/i18n_utils'
   extend Puppet::Acceptance::I18nUtils

--- a/acceptance/tests/i18n/translation_fallback.rb
+++ b/acceptance/tests/i18n/translation_fallback.rb
@@ -2,7 +2,8 @@ test_name 'C100560: puppet agent run output falls back to english when language 
   # No confines because even on non-translation supported OS' we should still fall back to english
 
   tag 'audit:medium',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
     step 'Run Puppet apply with language Hungarian and check the output' do

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -7,7 +7,8 @@ test_name 'C98346: Binary data type' do
                            # between server and agent transport/application.
                            # The weak link here is final ruby translation and
                            # should not be OS sensitive.
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -5,7 +5,8 @@ extend Puppet::Acceptance::EnvironmentUtils
 tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # This could be a component of a larger workflow scenario.
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
   skip_test 'requires puppetserver to service restart' if @options[:type] != 'aio'
 

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -3,7 +3,8 @@ test_name 'Puppet executes functions written in the Puppet language'
 tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # use mk_tmp_environment_with_teardown helper for environment construction
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 teardown do
   on master, 'rm -rf /etc/puppetlabs/code/modules/jenny'

--- a/acceptance/tests/language/objects_in_catalog.rb
+++ b/acceptance/tests/language/objects_in_catalog.rb
@@ -4,9 +4,10 @@ test_name 'C99627: can use Object types in the catalog and apply/agent' do
 
 tag 'audit:high',
     'audit:integration',
-    'audit:refactor'     # The use of apply on a reference system should
+    'audit:refactor',    # The use of apply on a reference system should
                          # be adequate to test puppet. Running this in
                          # context of server/agent should not be necessary.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
   manifest = <<-PP
 type Mod::Foo = Object[{

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -4,7 +4,8 @@ test_name 'C98345: ensure puppet generate assures env. isolation' do
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -3,7 +3,8 @@ test_name 'C98097 - generated pcore resource types should be loaded instead of r
 tag 'audit:high',
     'audit:integration',
     'audit:refactor',    # use `mk_tmp_environment_with_teardown` helper to build environment
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
   environment = 'production'
   step 'setup - install module with custom ruby resource type' do

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -1,7 +1,8 @@
 test_name "#7681: Allow using array variables in resource references"
 
 tag 'audit:high',
-    'audit:unit'
+    'audit:unit',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   test_manifest = <<MANIFEST

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -7,7 +7,8 @@ tag 'audit:high',
                           # between server and agent transport/application.
                           # Leaving at acceptance layer due to validate
                           # written logs.
-    'server'
+    'server',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -4,7 +4,8 @@ test_name 'C64667: ensure server_facts is set and error if any value is overwrit
 
 tag 'audit:high',
     'audit:acceptance', # Validating server/client interaction
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   teardown do
     agents.each do |agent|

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -1,5 +1,6 @@
 test_name 'C100303: Resource type statement triggered auto-loading works both with and without generated types' do
-  tag 'risk:high'
+  tag 'risk:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -21,7 +21,8 @@ require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 
 tag 'audit:high',
-    'audit:unit'    # This should be covered adequately by unit tests
+    'audit:unit',   # This should be covered adequately by unit tests
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 initialize_temp_dirs
 

--- a/acceptance/tests/loader/resource_triggers_autoload.rb
+++ b/acceptance/tests/loader/resource_triggers_autoload.rb
@@ -1,5 +1,6 @@
 test_name 'C100296: can auto-load defined types using a Resource statement' do
-  tag 'risk:high'
+  tag 'risk:high',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -7,7 +7,8 @@ tag 'audit:high',
     'audit:refactor',  # This test specifically tests interpolation on the master.
                        # Recommend adding an additonal test that validates
                        # lookup in a masterless setup.
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -8,7 +8,8 @@ tag 'audit:high',
     'audit:refactor',  # This test specifically tests interpolation on the master.
                        # Recommend adding an additonal test that validates
                        # lookup in a masterless setup.
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -8,6 +8,7 @@ tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/lookup/hiera_eyaml_backend.rb
+++ b/acceptance/tests/lookup/hiera_eyaml_backend.rb
@@ -5,7 +5,8 @@ test_name 'hiera-eyaml backend resolves encrypted values via eyaml_lookup_key' d
   extend Puppet::Acceptance::TempFileUtils
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -7,7 +7,8 @@ tag 'audit:high',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
                        # Use mk_tmp_environment_with_teardown to create environment.
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   testdir = master.tmpdir('lookup')
 

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -6,7 +6,8 @@ tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local environment.
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
   # The following two lines are required for the puppetserver service to
   # start correctly. These should be removed when PUP-7102 is resolved.

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -6,6 +6,7 @@ tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -6,6 +6,7 @@ tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -6,6 +6,7 @@ tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -1,5 +1,6 @@
 test_name 'Supports vendored modules' do
-  tag 'risk:high'
+  tag 'risk:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   # beacon custom type emits a message so we can tell where the
   # type was loaded from, e.g. vendored, global, and whether the

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -2,7 +2,8 @@ test_name "Puppet applies resources without dependencies in file order over the 
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 testdir = master.tmpdir('application_order')
 

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,7 +1,8 @@
 test_name 'Calling all functions.. test in progress!'
 
 tag 'audit:high',
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 # create single manifest calling all functions
 step 'Apply manifest containing all function calls'

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -2,7 +2,8 @@ test_name "Lookup data using the hiera parser function"
 
 tag 'audit:high',
     'audit:acceptance',
-    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+    'audit:refactor',   # Master is not required for this test. Replace with agents.each
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -2,7 +2,8 @@ test_name "Lookup data using the hiera_array parser function"
 
 tag 'audit:high',
     'audit:acceptance',
-    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+    'audit:refactor',   # Master is not required for this test. Replace with agents.each
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -2,7 +2,8 @@ test_name "Lookup data using the hiera_hash parser function"
 
 tag 'audit:high',
     'audit:acceptance',
-    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+    'audit:refactor',   # Master is not required for this test. Replace with agents.each
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 testdir = master.tmpdir('hiera')
 

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -2,7 +2,8 @@ test_name "Calling Hiera function from inside templates"
 
 tag 'audit:high',
     'audit:integration',
-    'audit:refactor'    # Master is not required for this test. Replace with agents.each
+    'audit:refactor',   # Master is not required for this test. Replace with agents.each
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 @module_name = "hieratest"
 @coderoot = master.tmpdir("#{@module_name}")

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -3,7 +3,8 @@ test_name 'C97760: Integer in reduce() should not cause exception' do
   extend Puppet::Acceptance::EnvironmentUtils
 
   tag 'audit:high',
-      'audit:unit'
+      'audit:unit',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # Remove all traces of the last used environment
   teardown do

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -2,8 +2,9 @@ test_name "Puppet Lookup Command"
 
 tag 'audit:high',
     'audit:acceptance',
-    'audit:refactor'   # Master is not required for this test. Replace with agents.each
+    'audit:refactor',  # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 # doc:
 # https://puppet.com/docs/puppet/latest/hiera_automatic.html

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -2,7 +2,8 @@ test_name "pluginsync should not error when modulepath is a symlink and no modul
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 step "Create a modulepath directory which is a symlink and includes a module without facts.d or lib directories"
 basedir = master.tmpdir("symlink_modulepath")

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,6 +1,7 @@
 test_name "Pluginsync'ed external facts should be resolvable on the agent" do
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
 #
 # This test is intended to ensure that external facts downloaded onto an agent via

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,7 +1,8 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs" do
 
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   #
   # This test is intended to ensure that custom facts downloaded onto an agent via

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,7 +1,8 @@
 test_name 'the pluginsync functionality should sync app definitions, and they should be runnable afterwards' do
 
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   #
   # This test is intended to ensure that pluginsync syncs app definitions to the agents.

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -2,7 +2,8 @@ test_name "the pluginsync functionality should sync app definitions, and they sh
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 #
 # This test is intended to ensure that pluginsync syncs face definitions to the agents.

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,7 +1,8 @@
 test_name "the pluginsync functionality should sync feature and function definitions" do
 
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   #
   # This test is intended to ensure that pluginsync syncs feature definitions to

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -2,7 +2,8 @@ test_name "earlier modules take precendence over later modules in the modulepath
 
 tag 'audit:high',
     'audit:integration',
-    'server'
+    'server',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 step "Create some modules in the modulepath"
 basedir = master.tmpdir("module_precedence")

--- a/acceptance/tests/provider/package/apt_install_package_with_range.rb
+++ b/acceptance/tests/provider/package/apt_install_package_with_range.rb
@@ -1,6 +1,7 @@
 test_name "apt can install range if package is not installed" do
   confine :to, :platform => /debian|ubuntu/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dnfmodule_enable_only.rb
+++ b/acceptance/tests/provider/package/dnfmodule_enable_only.rb
@@ -1,6 +1,7 @@
 test_name "dnfmodule can change flavors" do
   confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
+++ b/acceptance/tests/provider/package/dnfmodule_ensure_versionable.rb
@@ -1,6 +1,7 @@
 test_name "dnfmodule is versionable" do
   confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dnfmodule_manages_flavors.rb
+++ b/acceptance/tests/provider/package/dnfmodule_manages_flavors.rb
@@ -1,6 +1,7 @@
 test_name "dnfmodule can change flavors" do
   confine :to, :platform => /el-8-x86_64/  # only el/centos 8 have the appstream repo
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dpkg_ensure_latest_virtual_packages.rb
+++ b/acceptance/tests/provider/package/dpkg_ensure_latest_virtual_packages.rb
@@ -1,6 +1,7 @@
 test_name "dpkg ensure latest with allow_virtual set to true, the virtual package should detect and install a real package" do
   confine :to, :platform => /debian/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
@@ -1,6 +1,7 @@
 test_name "dpkg ensure hold package is latest installed" do
   confine :to, :platform => /debian-9-amd64/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/dpkg_hold_true_should_preserve_version.rb
+++ b/acceptance/tests/provider/package/dpkg_hold_true_should_preserve_version.rb
@@ -1,6 +1,7 @@
 test_name "dpkg ensure hold package should preserve version if package is already installed" do
   confine :to, :platform => /debian-9-amd64/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/gem.rb
+++ b/acceptance/tests/provider/package/gem.rb
@@ -1,6 +1,7 @@
 test_name "gem provider should install and uninstall" do
   confine :to, :template => /centos-7-x86_64|redhat-7-x86_64/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -1,6 +1,7 @@
 test_name "pip provider should install, use install_options with latest, and uninstall" do
   confine :to, :template => /centos/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/puppetserver_gem.rb
+++ b/acceptance/tests/provider/package/puppetserver_gem.rb
@@ -1,6 +1,7 @@
 test_name "puppetserver_gem provider should install and uninstall" do
   tag 'audit:high',
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/rpm_ensure_install_multiversion_package.rb
+++ b/acceptance/tests/provider/package/rpm_ensure_install_multiversion_package.rb
@@ -1,6 +1,7 @@
 test_name "rpm should install packages with multiple versions" do
   confine :to, :platform => /redhat|centos|el|fedora/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/yum_semantic_versioning.rb
+++ b/acceptance/tests/provider/package/yum_semantic_versioning.rb
@@ -1,6 +1,7 @@
 test_name "yum provider should use semantic versioning for ensuring desired version" do
   confine :to, :platform => /el-7/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/provider/package/zypper_install_package_with_range.rb
+++ b/acceptance/tests/provider/package/zypper_install_package_with_range.rb
@@ -1,6 +1,7 @@
 test_name "zypper can install range if package is not installed" do
   confine :to, :platform => /sles/
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::PackageUtils

--- a/acceptance/tests/r10k.rb
+++ b/acceptance/tests/r10k.rb
@@ -3,6 +3,8 @@
 # It does not test r10k functionality itself.
 test_name 'Can install and execute r10k with no gem conflicts'
 
+tag 'shard:group4'
+
 # On pre-8.23.0, we already had fast_gettext installed to the
 # /opt/puppetlabs/puppet/lib/ruby/vendor_gems/gems directory, so
 # when r10k was installed, it would not install fast_gettext to

--- a/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
+++ b/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
@@ -3,7 +3,8 @@ test_name "C100533: Agent sends json report for cached catalog" do
   tag 'risk:high',
       'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   with_puppet_running_on(master, :main => {}) do
     expected_format = 'json'

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -1,7 +1,8 @@
 test_name "PUP-5867: The report specifies whether a cached catalog was used, and if so, why" do
   tag 'audit:high',
       'audit:integration',
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   master_reportdir = create_tmpdir_for_user(master, 'report_dir')
 

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -10,7 +10,8 @@ test_name "C98092 - a new resource should not be reported as a corrective change
   tag 'audit:high',
       'audit:integration',
       'audit:refactor',    # Uses a server currently but is testing agent report
-      'broken:images'
+      'broken:images',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   test_file_name  = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -10,7 +10,8 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
   tag 'audit:high',
       'audit:integration',
       'audit:refactor',    # Uses a server currently, but is testing agent report
-      'broken:images'
+      'broken:images',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   test_file_name  = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -11,7 +11,8 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
       'audit:integration',
       'audit:refactor',    # Uses a server currently, but is testing agent report
       'broken:images',
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   test_file_name = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, test_file_name)

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -1,7 +1,8 @@
 test_name "Report submission"
 
 tag 'audit:high',
-    'audit:integration'
+    'audit:integration',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 if master.is_pe?
   require "time"

--- a/acceptance/tests/resource/exec/accept_array_commands.rb
+++ b/acceptance/tests/resource/exec/accept_array_commands.rb
@@ -1,6 +1,7 @@
 test_name "Be able to execute array commands" do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
     if agent.platform =~ /windows/

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -2,7 +2,8 @@ test_name "Be able to execute multi-line commands (#9996)"
 confine :except, :platform => 'windows'
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   temp_file_name = agent.tmpfile('9996-multi-line-commands')

--- a/acceptance/tests/resource/exec/should_accept_large_output.rb
+++ b/acceptance/tests/resource/exec/should_accept_large_output.rb
@@ -1,7 +1,8 @@
 test_name "tests that puppet correctly captures large and empty output."
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   testfile = agent.tmpfile('should_accept_large_output')

--- a/acceptance/tests/resource/exec/should_not_run_command_creates.rb
+++ b/acceptance/tests/resource/exec/should_not_run_command_creates.rb
@@ -1,7 +1,8 @@
 test_name "should not run command creates"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   touch      = agent.tmpfile('touched')

--- a/acceptance/tests/resource/exec/should_run_bad_command.rb
+++ b/acceptance/tests/resource/exec/should_run_bad_command.rb
@@ -1,7 +1,8 @@
 test_name "tests that puppet can run badly written scripts that fork and inherit descriptors"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 def sleepy_daemon_script(agent)
   if agent['platform'] =~ /win/

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -3,7 +3,8 @@ test_name "tests that puppet correctly runs an exec."
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 def before(agent)
   step "file to be touched should not exist."

--- a/acceptance/tests/resource/exec/should_run_command_as_user.rb
+++ b/acceptance/tests/resource/exec/should_run_command_as_user.rb
@@ -2,7 +2,8 @@ test_name "The exec resource should be able to run commands as a different user"
   confine :except, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::BeakerUtils

--- a/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
+++ b/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
@@ -1,6 +1,7 @@
 test_name "The Exec resource should run commands in the specified cwd" do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
   confine :except, :platform => /debian-12-amd64/ # PUP-12020
 
   require 'puppet/acceptance/windows_utils'

--- a/acceptance/tests/resource/exec/should_set_environment_variables.rb
+++ b/acceptance/tests/resource/exec/should_set_environment_variables.rb
@@ -1,6 +1,7 @@
 test_name "The Exec resource should set user-specified environment variables" do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   # Would be nice to parse the actual values from puppet_output,
   # but that would require some complicated matching since

--- a/acceptance/tests/resource/exec/should_set_path.rb
+++ b/acceptance/tests/resource/exec/should_set_path.rb
@@ -1,7 +1,8 @@
 test_name "the path statement should work to locate commands"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   file = agent.tmpfile('touched-should-set-path')

--- a/acceptance/tests/resource/file/ascii_diff_output_content_attribute.rb
+++ b/acceptance/tests/resource/file/ascii_diff_output_content_attribute.rb
@@ -1,6 +1,7 @@
 test_name "ASCII Diff Output of Content Attribute" do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   sha256 = Digest::SHA256.new
   agents.each do |agent|

--- a/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
+++ b/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
@@ -1,6 +1,7 @@
 test_name "Binary Diff Output of Content Attribute" do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # cannot test binary diff on windows2012r2_ja-64-1
   # Error: Could not write report for afire-lien.delivery.puppetlabs.net at C:/ProgramData/PuppetLabs/puppet/cache/reports/afire-lien.delivery.puppetlabs.net/201912041455.yaml: anchor value must contain alphanumerical characters only

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -1,7 +1,8 @@
 test_name "Content Attribute"
 tag 'audit:high',
     'audit:refactor',   # Use block stype test_name
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target = agent.tmpfile('content_file_test')

--- a/acceptance/tests/resource/file/handle_fifo_files.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files.rb
@@ -1,6 +1,7 @@
 test_name "should be able to handle fifo files"
 tag 'audit:high',
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 confine :except, :platform => /windows/
 
 def ensure_content_to_file_manifest(file_path, ensure_value)

--- a/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
@@ -1,6 +1,7 @@
 test_name "should be able to handle fifo files when recursing"
 tag 'audit:high',
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 confine :except, :platform => /windows/
 
 def ensure_owner_recursively_manifest(path, owner_value)

--- a/acceptance/tests/resource/file/should_create_directory.rb
+++ b/acceptance/tests/resource/file/should_create_directory.rb
@@ -1,7 +1,8 @@
 test_name "should create directory"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target = agent.tmpfile("create-dir")

--- a/acceptance/tests/resource/file/should_create_empty.rb
+++ b/acceptance/tests/resource/file/should_create_empty.rb
@@ -1,7 +1,8 @@
 test_name "should create empty file for 'present'"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target = agent.tmpfile("empty")

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -1,7 +1,8 @@
 test_name "should create symlink"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 def message
   'hello world'

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -1,7 +1,8 @@
 test_name "file resource: set default modes"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 def regexp_mode(mode)
   Regexp.new("mode\s*=>\s*'0?#{mode}'")

--- a/acceptance/tests/resource/file/should_remove_dir.rb
+++ b/acceptance/tests/resource/file/should_remove_dir.rb
@@ -1,7 +1,8 @@
 test_name "should remove directory, but force required"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target = agent.tmpdir("delete-dir")

--- a/acceptance/tests/resource/file/should_remove_file.rb
+++ b/acceptance/tests/resource/file/should_remove_file.rb
@@ -1,7 +1,8 @@
 test_name "should remove file"
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target = agent.tmpfile('delete-file')

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -4,7 +4,8 @@ test_name "The source attribute" do
 
   tag 'audit:high',
       'audit:acceptance',
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   @target_file_on_windows = 'C:/windows/temp/source_attr_test'
   @target_file_on_nix     = '/tmp/source_attr_test'

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -3,7 +3,8 @@ test_name 'file resource: symbolic modes' do
   confine :to, {}, hosts.select {|host| !host[:roles].include?('master')}
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/temp_file_utils'
   extend Puppet::Acceptance::TempFileUtils

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -2,7 +2,8 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
   tag 'audit:high',
       'broken:images',
       'audit:acceptance',
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -2,7 +2,8 @@ test_name "#7680: 'links => follow' should use the file source content"
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
 

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -5,7 +5,8 @@ confine :except, :platform => 'osx'
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 target = "/test-socket-#{$$}"
 

--- a/acceptance/tests/resource/group/should_create.rb
+++ b/acceptance/tests/resource/group/should_create.rb
@@ -2,9 +2,10 @@ test_name "should create a group"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_destroy.rb
+++ b/acceptance/tests/resource/group/should_destroy.rb
@@ -2,9 +2,10 @@ test_name "should destroy a group"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_manage_attributes_aix.rb
+++ b/acceptance/tests/resource/group/should_manage_attributes_aix.rb
@@ -2,10 +2,11 @@ test_name "should correctly manage the attributes property for the Group (AIX on
   confine :to, :platform => /aix/
   
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
   
   require 'puppet/acceptance/aix_util'
   extend Puppet::Acceptance::AixUtil

--- a/acceptance/tests/resource/group/should_manage_members.rb
+++ b/acceptance/tests/resource/group/should_manage_members.rb
@@ -4,10 +4,11 @@ test_name "should correctly manage the members property for the Group resource" 
   confine :to, :platform => /windows|osx|aix|^el-|fedora/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::BeakerUtils

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -3,9 +3,10 @@ confine :except, :platform => 'windows'
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 gid1  = (rand(989999).to_i + 10000)

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -2,9 +2,10 @@ test_name "group should not create existing group"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 name = "gr#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_not_destroy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destroy_unexisting.rb
@@ -2,9 +2,10 @@ test_name "should not destroy a group that doesn't exist"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 name = "test-group-#{Time.new.to_i}"
 

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -2,9 +2,10 @@ test_name "test that we can query and find a group that exists."
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -2,7 +2,8 @@ test_name "should query all groups"
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:integration' # Does not modify system running test
+    'audit:integration',# Does not modify system running test
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -12,7 +12,8 @@ test_name "ticket 1073: common package name in two different providers should be
   end
 
   tag 'audit:high',
-      'audit:acceptance' # Uses a provider that depends on AIO packaging
+      'audit:acceptance',# Uses a provider that depends on AIO packaging
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/rpm_util'
   extend Puppet::Acceptance::RpmUtils

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -2,9 +2,10 @@
 test_name "Puppet returns only resource package declaration when querying an uninstalled package" do
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done at the integration (or unit) layer though
+      'audit:acceptance',# Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
 

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_updatable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updatable.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_updateable_and_unholdable_at_same_time.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updateable_and_unholdable_at_same_time.rb
@@ -1,7 +1,8 @@
 test_name "Package:IPS test for updatable holded package" do
   confine :to, :platform => 'solaris-11'
 
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/solaris_util'
   extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_create.rb
+++ b/acceptance/tests/resource/package/ips/should_create.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_query.rb
+++ b/acceptance/tests/resource/package/ips/should_query.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -3,9 +3,10 @@ confine :to, :platform => 'solaris-11'
 
 tag 'audit:medium',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::IPSUtils

--- a/acceptance/tests/resource/package/windows.rb
+++ b/acceptance/tests/resource/package/windows.rb
@@ -2,7 +2,8 @@ test_name "Windows Package Provider" do
   confine :to, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/windows_utils'
   extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -12,9 +12,10 @@ test_name "test the yum package provider" do
   end
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done at the integration (or unit) layer though
+      'audit:acceptance',# Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/rpm_util'
   extend Puppet::Acceptance::RpmUtils

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -2,9 +2,10 @@ test_name 'AIX Service Provider Testing'
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 confine :to, :platform =>  'aix'
 

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -6,9 +6,10 @@ test_name 'SysV on default Systemd Service Provider Validation' do
   end
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done at the integration (or unit) layer though
+      'audit:acceptance',# Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/service_utils'
   extend Puppet::Acceptance::ServiceUtils

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -2,9 +2,10 @@ test_name 'Mac OS X launchd Provider Testing'
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 confine :to, {:platform => /osx/}, agents
 

--- a/acceptance/tests/resource/service/puppet_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_service_management.rb
@@ -2,12 +2,13 @@ test_name "The Puppet service should be manageable with Puppet"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
-    'audit:acceptance' # uses services from a running puppet-agent install
+    'audit:acceptance',# uses services from a running puppet-agent install
 #
 # This test is intended to ensure that the Puppet service can
 # be directly managed by Puppet. See PUP-5053, PUP-5257, and RE-5574 for
 # more context around circumstances that this can fail.
 #
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 skip_test 'requires puppet service scripts from AIO agent package' if @options[:type] != 'aio'
 

--- a/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
+++ b/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
@@ -4,7 +4,8 @@ extend Puppet::Acceptance::ServiceUtils
 test_name 'Starting the puppet service should successfully run puppet' do
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   skip_test 'requires a server node to run puppet agent -t' unless master
 

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -3,9 +3,10 @@ test_name 'SysV and Systemd Service Provider Validation'
 tag 'audit:high',
     'audit:refactor',  # Investigate merging with init_on_systemd.rb
                        # Use block style `test_name`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 confine :to, :platform => /el-|centos|fedora|debian|sles|ubuntu-v/
 # osx covered by launchd_provider.rb

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -2,7 +2,8 @@ test_name "`puppet resource service` should list running services without callin
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:integration' # Doesn't change the system it runs on
+    'audit:integration',# Doesn't change the system it runs on
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 confine :except, :platform => 'windows'
 confine :except, :platform => 'solaris'

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -3,7 +3,8 @@ test_name "should query all services"
 tag 'audit:high',
     'audit:refactor',   # Investigate combining with should_not_change_the_system.rb
                         # Use block style `test_name`
-    'audit:integration' # Doesn't change the system it runs on
+    'audit:integration',# Doesn't change the system it runs on
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   step "query with puppet"

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -2,9 +2,10 @@ test_name "SMF: basic tests" do
   confine :to, :platform => 'solaris'
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done at the integration (or unit) layer though
+      'audit:acceptance',# Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/solaris_util'
   extend Puppet::Acceptance::SMFUtils

--- a/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
+++ b/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
@@ -3,7 +3,8 @@ extend Puppet::Acceptance::ServiceUtils
 
 test_name 'systemd service shows correct output when queried with "puppet resource"' do
 
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   skip_test 'requires puppet service script from AIO agent package' if @options[:type] != 'aio'
 

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -5,9 +5,10 @@ test_name 'Systemd masked services are unmasked before attempting to start'
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done at the integration (or unit) layer though
+    'audit:acceptance',# Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
                        # host running this, or require special permissions.
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 skip_test "requires AIO install to require 'puppet'" if @options[:type] != 'aio'
 

--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -2,7 +2,8 @@ test_name "Windows Service Provider" do
   confine :to, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/windows_utils'
   extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/service/windows_mixed_utf8.rb
+++ b/acceptance/tests/resource/service/windows_mixed_utf8.rb
@@ -3,7 +3,8 @@ test_name "Windows Service Provider With Mixed UTF-8 Service Names" do
   confine :to, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/windows_utils'
   extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -2,7 +2,8 @@
 # different matches should not cause error as found in the bug PUP-6508
 test_name "PUP-6655 - C98145 tidy resources should be non-isomorphic" do
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   agents. each do |agent|
     dir = agent.tmpdir('tidy-test-dir')

--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -2,7 +2,8 @@ test_name "Tidying files by date"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:integration'
+    'audit:integration',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   step "Create a directory of old and new files"

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
@@ -2,10 +2,11 @@ test_name "should not modify the home directory of an user on OS X >= 10.14" do
   confine :to, :platform => /osx/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::BeakerUtils

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
@@ -2,10 +2,11 @@ test_name "should not modify the uid of an user on OS X >= 10.14" do
   confine :to, :platform => /osx/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::BeakerUtils

--- a/acceptance/tests/resource/user/should_allow_managed_macos_users_to_login.rb
+++ b/acceptance/tests/resource/user/should_allow_managed_macos_users_to_login.rb
@@ -3,10 +3,11 @@ test_name "should allow managed macOS users to login" do
   confine :to, :platform => /osx/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
 
   # Two different test cases, with additional environment setup inbetween,

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -2,10 +2,11 @@ test_name "should create a user"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_create_modify_with_password.rb
+++ b/acceptance/tests/resource/user/should_create_modify_with_password.rb
@@ -3,10 +3,11 @@
 test_name 'should create a user with password and modify the password' do
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
   # require changing the system running the test
   # in ways that might require special permissions
   # or be harmful to the system running the test
+      'shard:group2' # For splitting out groups of tests for slow test runners
   
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::ManifestUtils

--- a/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
+++ b/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
@@ -2,10 +2,11 @@ test_name "verifies that puppet resource creates a user and assigns the correct 
   confine :except, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   user = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -3,10 +3,11 @@ confine :except, :platform => 'windows'
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 user = "pl#{rand(999999).to_i}"
 group = "gp#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -2,10 +2,11 @@ test_name "should delete a user"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_destroy_with_managehome.rb
+++ b/acceptance/tests/resource/user/should_destroy_with_managehome.rb
@@ -2,10 +2,11 @@ test_name "should delete a user with managehome=true" do
   confine :except, :platform => /osx/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
     home = ''

--- a/acceptance/tests/resource/user/should_manage_attributes_aix.rb
+++ b/acceptance/tests/resource/user/should_manage_attributes_aix.rb
@@ -2,10 +2,11 @@ test_name "should correctly manage the attributes property for the User resource
   confine :to, :platform => /aix/
   
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
   
   require 'puppet/acceptance/aix_util'
   extend Puppet::Acceptance::AixUtil

--- a/acceptance/tests/resource/user/should_manage_groups.rb
+++ b/acceptance/tests/resource/user/should_manage_groups.rb
@@ -7,10 +7,11 @@ test_name "should correctly manage the groups property for the User resource" do
   confine :except, :platform => /windows/
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/common_utils'
   extend Puppet::Acceptance::BeakerUtils

--- a/acceptance/tests/resource/user/should_manage_purge_ssh_keys.rb
+++ b/acceptance/tests/resource/user/should_manage_purge_ssh_keys.rb
@@ -1,6 +1,7 @@
 test_name 'should manage purge_ssh_keys' do
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   # MODULES-11236
   # This test does not work on Windows nor macOS

--- a/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
+++ b/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
@@ -2,7 +2,8 @@ test_name "Manage roles for a Windows user" do
   confine :to, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   require 'puppet/acceptance/windows_utils'
   extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -2,10 +2,11 @@ test_name "should manage user shell"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_modify.rb
+++ b/acceptance/tests/resource/user/should_modify.rb
@@ -1,10 +1,11 @@
 test_name "should modify a user"
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_modify_gid.rb
+++ b/acceptance/tests/resource/user/should_modify_gid.rb
@@ -4,10 +4,11 @@ confine :except, :platform => /aix/ # PUP-5358
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 user = "u#{rand(99999).to_i}"
 group1 = "#{user}o"

--- a/acceptance/tests/resource/user/should_modify_gid_forcelocal.rb
+++ b/acceptance/tests/resource/user/should_modify_gid_forcelocal.rb
@@ -5,7 +5,8 @@ test_name "verify that we can modify the gid with forcelocal" do
   extend Puppet::Acceptance::PackageUtils
   extend Puppet::Acceptance::ManifestUtils
 
-  tag 'audit:high'
+  tag 'audit:high',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   user = "u#{rand(99999).to_i}"
   group1 = "#{user}o"

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -2,10 +2,11 @@ test_name "should modify a user when no longer managing home (#20726)"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -2,10 +2,11 @@ test_name "should modify a user without changing home directory (pending #19542)
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/windows_utils'
 extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,10 +1,11 @@
 test_name "tests that user resource will not add users that already exist." do
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   user  = "u#{rand(999999).to_i}"
   group = "g#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
@@ -2,10 +2,11 @@ test_name "ensure that puppet does not report removing a user that does not exis
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -3,10 +3,11 @@ test_name 'PUP-6586 Ensure puppet does not continually reset password for disabl
   confine :to, :platform => 'windows'
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   name = "pl#{rand(99999).to_i}"
 

--- a/acceptance/tests/resource/user/should_purge.rb
+++ b/acceptance/tests/resource/user/should_purge.rb
@@ -4,7 +4,8 @@ test_name "should purge a user" do
   confine :except, :platform => /^solaris/
   confine :except, :platform => /^osx/
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
     unmanaged = "unmanaged-#{rand(999999).to_i}"

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -2,10 +2,11 @@ test_name "test that we can query and find a user that exists."
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
+    'audit:acceptance',# Could be done as integration tests, but would
                        # require changing the system running the test
                        # in ways that might require special permissions
                        # or be harmful to the system running the test
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 name = "pl#{rand(999999).to_i}"
 

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -2,7 +2,8 @@ test_name "should query all users"
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
-    'audit:integration'
+    'audit:integration',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   next if agent == master

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -10,10 +10,11 @@
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
   tag 'audit:high',
-      'audit:acceptance' # Could be done as integration tests, but would
+      'audit:acceptance',# Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions
                          # or be harmful to the system running the test
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   # AIX providers are separate from most other platforms,
   # and have not been made unicode-aware yet.

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -4,7 +4,8 @@
 test_name "CVE 2013-1640 Remote Code Execution" do
 
   tag 'audit:high',       # low risk, high (security) impact
-      'audit:integration'
+      'audit:integration',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   confine :except, :platform => 'windows'
 

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -7,7 +7,8 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
 
   tag 'audit:high',        # risk low, high (security) impact
       'audit:integration',
-      'server'
+      'server',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   with_puppet_running_on master, {} do
     # Ensure each agent has a signed cert

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -2,7 +2,8 @@ test_name "CVE 2013-1652 Poison node cache" do
 
   tag 'audit:high',        # low risk, high (security) impact
       'audit:integration', # master side only
-      'server'
+      'server',
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   step "Determine suitability of the test" do
     skip_test( "This test will only run on Puppet 3.x" ) if

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -3,7 +3,8 @@ test_name "(#19531) report save access control"
 tag 'audit:high',        # low risk, high (security) impact
     'audit:refactor',    # Use block style `test_name`
     'audit:integration', # issue completely on the server side
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 step "Verify puppet only allows saving reports from the node matching the certificate"
 

--- a/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
+++ b/acceptance/tests/security/cve-2013-4761_injection_of_class_names_loading_code.rb
@@ -3,7 +3,8 @@ test_name "CVE 2013-4761 Injection of bad class names causing code loading" do
 
   tag 'audit:high',        # low risk, high (security) impact
       'audit:integration', # issue is completely on the master side
-      'server'
+      'server',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   testdir = create_tmpdir_for_user master, 'class-names-injection'
   exploit_path = "#{testdir}/exploit.rb"

--- a/acceptance/tests/ssl/autosign_command.rb
+++ b/acceptance/tests/ssl/autosign_command.rb
@@ -3,7 +3,8 @@ test_name "autosign command and csr attributes behavior (#7243,#7244)" do
 
   tag 'audit:high',        # cert/ca core behavior
       'audit:integration',
-      'server'             # Ruby implementation is deprecated
+      'server',            # Ruby implementation is deprecated
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   def assert_key_generated(name, stdout)
     assert_match(/Creating a new RSA SSL key for #{name}/, stdout, "Expected agent to create a new SSL key for autosigning")

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -6,7 +6,8 @@ test_name "certificate extensions available as trusted data" do
 
   tag 'audit:high',        # ca/cert core functionality
       'audit:integration',
-      'server'             # Ruby implementation is deprecated
+      'server',            # Ruby implementation is deprecated
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   initialize_temp_dirs
 

--- a/acceptance/tests/ssl/trusted_external_facts.rb
+++ b/acceptance/tests/ssl/trusted_external_facts.rb
@@ -18,7 +18,8 @@ test_name "trusted external fact test" do
   ### END HELPERS ###
 
   tag 'audit:high',        # external facts
-    'server'
+    'server',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
   skip_test 'requires a master for serving module content' if master.nil?
 

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -1,7 +1,8 @@
 test_name 'C99977 corrupted clientbucket' do
 
   tag 'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
     tmpfile = agent.tmpfile('c99977file')

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -7,7 +7,8 @@ extend Puppet::Acceptance::TempFileUtils
 tag 'audit:high',      # tests basic custom module/pluginsync handling?
     'audit:refactor',    # Use block style `test_namme`
     'audit:integration',
-    'server'
+    'server',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 initialize_temp_dirs()
 all_tests_passed = false

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -4,7 +4,8 @@ tag 'audit:high',
     'audit:refactor',  # Use block style `test_namme`
                        # refactor to be OS agnostic and added to the resource/user
                        # tests. managehome is currently not covered there.
-    'audit:acceptance'
+    'audit:acceptance',
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
+++ b/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
@@ -1,7 +1,8 @@
 test_name 'C100297 - A resource triggered by a refresh that fails should be reported as a failure when using --detailed-exitcodes' do
 
   tag 'audit:high',
-      'audit:integration' # Service type interaction with --detailed-exitcodes
+      'audit:integration',# Service type interaction with --detailed-exitcodes
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   manifest =<<EOS
     exec{'true':

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -4,7 +4,8 @@ tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
                        # Use mk_tmp_environment_with_teardown
                        # Combine with Service resource tests
-    'audit:acceptance' # Service provider functionality
+    'audit:acceptance',# Service provider functionality
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 skip_test unless agents.any? {|agent| agent['platform'] =~ /solaris/ }
 

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -8,7 +8,8 @@ test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file
 tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # Use block style `test_name`
-    'server'
+    'server',
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 testdir = master.tmpdir('missing_site_pp')
 manifest_file = "#{testdir}/environments/production/manifests/site.pp"

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -1,7 +1,8 @@
 test_name 'Ensure hiera lookup occurs if class param is undef' do
 
   tag 'audit:high',
-      'audit:unit'    # basic auto lookup functionality
+      'audit:unit',   # basic auto lookup functionality
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   agents.each do |agent|
 

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -2,8 +2,9 @@ test_name "#6541: file type truncates target when filebucket cannot retrieve has
 
 tag 'audit:high',
     'audit:integration', # file type and file bucket interop
-    'audit:refactor'     # look into combining with ticket_4622_filebucket_diff_test.rb
+    'audit:refactor',    # look into combining with ticket_4622_filebucket_diff_test.rb
                          # Use block style `test_run`
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   target=agent.tmpfile('6541-target')

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -2,7 +2,8 @@ test_name "#6857: redact password hashes when applying in noop mode"
 
 tag 'audit:high',
     'audit:refactor',    # Use block style `test_name`
-    'audit:integration'
+    'audit:integration',
+    'shard:group4' # For splitting out groups of tests for slow test runners
 
 require 'puppet/acceptance/common_utils'
 extend Puppet::Acceptance::CommandUtils

--- a/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
+++ b/acceptance/tests/ticket_6907_use_provider_in_same_run_it_becomes_suitable.rb
@@ -2,7 +2,8 @@ test_name "providers should be useable in the same run they become suitable"
 
 tag 'audit:high',       # autoloader, core puppet agent run functionality
     'audit:refactor',    # Use block style `test_name`
-    'audit:integration' # does not require packages, probably implicitly assumed in many other places
+    'audit:integration',# does not require packages, probably implicitly assumed in many other places
+    'shard:group1' # For splitting out groups of tests for slow test runners
 
 agents.each do |agent|
   dir = agent.tmpdir('provider-6907')

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -5,6 +5,7 @@ tag 'audit:high',     # startup/configuration, high impact, low risk
     'audit:integration' # could easily be acceptance, not package dependant,
                         # but changing a person running the tests users and
                         # groups can be very onerous
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 # puppet doesn't try to manage ownership on windows.
 confine :except, :platform => 'windows'

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -3,7 +3,8 @@ test_name 'utf-8 characters in cached catalog' do
   tag 'audit:high', # utf-8 is high impact in general
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
       'audit:refactor', # use mk_tmp_environment_with_teardown
-      'server'
+      'server',
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   utf8chars     = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"
   file_content  = "This is the file content. file #{utf8chars}"

--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -1,7 +1,8 @@
 test_name 'utf-8 characters in resource title and param values' do
 
   tag 'audit:high',       # utf-8 is high impact in general
-      'audit:integration' # not package dependent but may want to vary platform by LOCALE/encoding
+      'audit:integration',# not package dependent but may want to vary platform by LOCALE/encoding
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   confine :except, :platform => [
     'windows',    # PUP-6983

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -3,7 +3,8 @@ test_name 'utf-8 characters in function parameters' do
 
   tag 'audit:high',
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
-      'audit:refactor'     # if keeping, use mk_tmp_environment_with_teardown
+      'audit:refactor',    # if keeping, use mk_tmp_environment_with_teardown
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   confine :except, :platform => [
     'windows',      # PUP-6983

--- a/acceptance/tests/utf8/utf8-in-puppet-describe.rb
+++ b/acceptance/tests/utf8/utf8-in-puppet-describe.rb
@@ -2,9 +2,10 @@ test_name 'utf-8 characters in module doc string, puppet describe' do
 
   tag 'audit:high',      # utf-8 is high impact in general, puppet describe low risk?
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
-      'audit:refactor'     # if keeping, use mk_tmp_environment_with_teardown
+      'audit:refactor',    # if keeping, use mk_tmp_environment_with_teardown
                            # remove with_puppet_running_on unless pluginsync is absolutely necessary
                            # (if it is, add 'server' tag
+      'shard:group2' # For splitting out groups of tests for slow test runners
 
   # utf8chars = "€‰ㄘ万竹ÜÖ"
   utf8chars = "\u20ac\u2030\u3118\u4e07\u7af9\u00dc\u00d6"

--- a/acceptance/tests/utf8/utf8-recursive-copy.rb
+++ b/acceptance/tests/utf8/utf8-recursive-copy.rb
@@ -1,7 +1,8 @@
 test_name "PUP-8735: UTF-8 characters are preserved after recursively copying directories" do
 
   tag 'audit:high', # utf-8 is high impact in general
-      'audit:integration' # not package dependent but may want to vary platform by LOCALE/encoding
+      'audit:integration',# not package dependent but may want to vary platform by LOCALE/encoding
+      'shard:group3' # For splitting out groups of tests for slow test runners
 
   # Translation is not supported on these platforms:
   confine :except, :platform => /^solaris/

--- a/acceptance/tests/windows/PA-2191_windows_nocodepage_utf8_fallback.rb
+++ b/acceptance/tests/windows/PA-2191_windows_nocodepage_utf8_fallback.rb
@@ -2,7 +2,8 @@ test_name 'PA-2191 - winruby fallsback to UTF8 for invalid CodePage' do
   confine :to, platform: 'windows'
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   agents.each do |host|
 

--- a/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
+++ b/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
@@ -3,7 +3,8 @@
 test_name 'PUP-9719 Windows First Agent run as SYSTEM sets cache file permissions correctly' do
   tag 'risk:high',
       'audit:high',
-      'audit:integration'
+      'audit:integration',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   confine :to, platform: 'windows'
 

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -3,10 +3,11 @@ test_name "Windows Exec `exit_code` Parameter Acceptance Test"
 tag 'risk:high',
     'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:integration' # exec resource succeeds when the `exit_code` parameter
+    'audit:integration',# exec resource succeeds when the `exit_code` parameter
                         # is given a windows specific exit code and a exec
                         # returns that exit code, ie. it either correctly matches
                         # exit_code parameter to returned exit code, or ignores both (;
+    'shard:group2' # For splitting out groups of tests for slow test runners
 
 confine :to, :platform => 'windows'
 

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -3,7 +3,8 @@ test_name "QA-760 - Windows Files Containing '-' and '.'"
 tag 'risk:high',
     'audit:high',
     'audit:refactor',   # Use block style `test_name`
-    'audit:integration'
+    'audit:integration',
+    'shard:group3' # For splitting out groups of tests for slow test runners
 
 confine(:to, :platform => 'windows')
 

--- a/acceptance/tests/windows/enable_password_changes_special_users.rb
+++ b/acceptance/tests/windows/enable_password_changes_special_users.rb
@@ -1,7 +1,8 @@
 test_name 'Puppet should change passwords for disabled, expired, or locked out Windows user accounts' do
 
   tag 'audit:high',
-      'audit:acceptance'
+      'audit:acceptance',
+      'shard:group4' # For splitting out groups of tests for slow test runners
 
   require 'date'
   require 'puppet/acceptance/windows_utils'

--- a/acceptance/tests/windows/service_manager_integration.rb
+++ b/acceptance/tests/windows/service_manager_integration.rb
@@ -1,6 +1,7 @@
 test_name 'Test agent state via service control manager' do
 
-  tag 'audit:integration'
+  tag 'audit:integration',
+      'shard:group1' # For splitting out groups of tests for slow test runners
 
   confine :to, platform: 'windows'
 


### PR DESCRIPTION
### Short description
Allows running the acceptance suite in gha against arm64 vms.

Requires openvoxproject/shared-actions#99.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
