### PR TITLE
Allow any character after # in FreeBSD rc scripts

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
   def rcvar
     rcvar = execute([initscript, :rcvar], :failonfail => true, :combine => false, :squelch => false)
     rcvar = rcvar.split("\n")
-    rcvar.delete_if { |str| str =~ /^#\s*$/ }
+    rcvar.delete_if { |str| str =~ /^#.*$/ }
     rcvar[1] = rcvar[1].gsub(/^\$/, '')
     rcvar
   end


### PR DESCRIPTION
### Short description

Without this, services like nginx fail on FreeBSD (any version) with `Error: /Stage[main]/Nginx::Service/Service[nginx]: Could not evaluate: rcvar value is empty` if profiles are used. Other scripts may fail if the `rcvar` command emits comment lines with non-string characters following the `#`.

Assuming we don't care what comes after the `#`, allow any character until end of line.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
