### PR TITLE
Explicitly check out main branch during backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
+          ref: main
       - name: Create backport pull requests
         uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
         with:


### PR DESCRIPTION
The v7 release of `actions/checkout` introduced a major change where it will refuse to check out repository state that may be mutated by the pull request. This commit explicitly sets `ref: main` on the checkout step of the workflow as `korthout/backport-action` has logic for finding the pull request and cherry-picking commits out of it.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
