### PR TITLE
Fix handling of Puppet::Pops serialization issues

### DIFF
--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -305,7 +305,7 @@ module Serialization
         if tos.empty?
           semantic = Puppet::Pops::SemanticError.new(issue, nil, EMPTY_HASH)
         else
-          file, line = stacktrace
+          file, line = Puppet::Pops::PuppetStack.stacktrace
           semantic = Puppet::Pops::SemanticError.new(issue, nil, { :file => file, :line => line })
         end
       end

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -525,7 +525,7 @@ module Serialization
       expect(warnings).to eql([
         "Test Hash contains a hash with a SemanticPuppet::Version key. It will be converted to the String '1.0.0'",
         "Test Hash contains a hash with a SemanticPuppet::Version key. It will be converted to the String '2.0.0'"])
-      end
+    end
 
     it 'A Hash with rich data is not converted and raises error by default' do
       Puppet[:strict] = :error
@@ -564,6 +564,17 @@ module Serialization
         val = { 'key' => :default  }
         Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
           write(val)
+          val2 = read
+          expect(val2).to be_a(Hash)
+          expect(val2).to eql({ 'key' => 'default' })
+        end
+        expect(warnings).to eql(["['key'] contains the special value default. It will be converted to the String 'default'"])
+      end
+
+      it 'A Hash with default values will have the values converted to string with a warning when not at top-of-stack' do
+        val = { 'key' => :default  }
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          Puppet::Pops::PuppetStack.stack('afile', 1234, self, :write, [val])
           val2 = read
           expect(val2).to be_a(Hash)
           expect(val2).to eql({ 'key' => 'default' })


### PR DESCRIPTION
### Short description

In `Puppet::Pops::Serialization::ToDataConverter` a number of different issues can occur during serialization. If an issue is generated and the PuppetStack is not at the top of stack it attempts to include file/line position information but the method call to `stacktrace` isn't in scope at the call, causing a fatal error. Calling `Puppet::Pops::PuppetStack.stacktrace` obtains the desired stacktrace for position information.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
