### PR TITLE
Tolerate concurrent creation of directories

### DIFF
--- a/lib/puppet/type/file/ensure.rb
+++ b/lib/puppet/type/file/ensure.rb
@@ -86,12 +86,21 @@ module Puppet
         raise Puppet::Error,
               "Cannot create #{@resource[:path]}; parent directory #{parent} does not exist"
       end
-      if mode
-        Puppet::Util.withumask(0o00) do
-          Dir.mkdir(@resource[:path], symbolic_mode_to_int(mode, 0o755, true))
+      begin
+        if mode
+          Puppet::Util.withumask(0o00) do
+            Dir.mkdir(@resource[:path], symbolic_mode_to_int(mode, 0o755, true))
+          end
+        else
+          Dir.mkdir(@resource[:path])
         end
-      else
-        Dir.mkdir(@resource[:path])
+      rescue Errno::EEXIST
+        # Another process may have created the directory concurrently. If it
+        # really is a directory now, treat that as success.
+        #
+        # Directory mode, and other properties, will be checked and enforced by
+        # the call to `property_fix`.
+        raise unless Puppet::FileSystem.directory?(@resource[:path])
       end
       @resource.send(:property_fix)
       return :directory_created

--- a/spec/unit/type/file/ensure_spec.rb
+++ b/spec/unit/type/file/ensure_spec.rb
@@ -116,6 +116,24 @@ describe Puppet::Type.type(:file).attrclass(:ensure) do
 
         property.sync
       end
+
+      it "should not raise if the directory was created concurrently by another process" do
+        expect(Dir).to receive(:mkdir).with(path).and_raise(Errno::EEXIST)
+        expect(Puppet::FileSystem).to receive(:directory?).with(path).and_return(true)
+        expect(resource).to receive(:property_fix)
+
+        expect(property.sync).to eq(:directory_created)
+      end
+
+      it "should raise if the path exists but is not a directory" do
+        expect(Dir).to receive(:mkdir).with(path).and_raise(Errno::EEXIST)
+        expect(Puppet::FileSystem).to receive(:directory?).with(path).and_return(false)
+        expect(resource).not_to receive(:property_fix)
+
+        expect {
+          property.sync
+        }.to raise_error(Puppet::ResourceError, /File exists/)
+      end
     end
   end
 end


### PR DESCRIPTION
### Short description

When two processes both decide a directory needs to be created (e.g. multiple JRuby instances in openvox-server independently bootstrapping Puppet settings against the same confdir), Dir.mkdir raises Errno::EEXIST for whichever one loses the race, surfacing as a resource failure even though the desired state was actually achieved. Treat EEXIST as success when the path is now a directory, while still raising for a genuine conflict (e.g. a file or symlink already at that path).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
