### PR TITLE
Revert "require 'set'" removals

### DIFF
--- a/lib/puppet/graph/simple_graph.rb
+++ b/lib/puppet/graph/simple_graph.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../puppet/external/dot'
 require_relative '../../puppet/relationship'
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 
 # A hopefully-faster graph class to replace the use of GRATR.
 class Puppet::Graph::SimpleGraph

--- a/lib/puppet/module_tool/metadata.rb
+++ b/lib/puppet/module_tool/metadata.rb
@@ -4,6 +4,7 @@ require_relative '../../puppet/module_tool'
 require_relative '../../puppet/network/format_support'
 require 'uri'
 require_relative '../../puppet/util/json'
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 
 module Puppet::ModuleTool
   # This class provides a data structure representing a module's metadata.

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../puppet/provider/package'
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 require 'uri'
 
 Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Package do

--- a/lib/puppet/settings/base_setting.rb
+++ b/lib/puppet/settings/base_setting.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 require_relative '../../puppet/settings/errors'
 
 # The base setting type

--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -5,6 +5,7 @@ require_relative '../puppet/util/tagging'
 require_relative '../puppet/util/skip_tags'
 require_relative '../puppet/application'
 require 'digest/sha1'
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 
 # the class that actually walks our resource/property tree, collects the changes,
 # and performs them

--- a/lib/puppet/util/tag_set.rb
+++ b/lib/puppet/util/tag_set.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'set' # rubocop:disable Lint/RedundantRequireStatement
 require_relative '../../puppet/network/format_support'
 
 class Puppet::Util::TagSet < Set


### PR DESCRIPTION
### Short description

This commit reverts the removals of `require 'set'` that were done in OpenVoxProject/openvox#442. This `require` is no longer needed with Ruby 3.2 and newer, yet JRuby 9.4 implements Ruby 3.1 so this is currently causing test failures until JRuby 10 lands in OpenVox Server.

Using `require 'set'` is a no-op on newer Ruby versions. This commit can its self be reverted at a later date once the ecosystem fully supports Ruby 3.2 and newer.

This partially reverts commit e83c37b57d576d82e3137fcf9f6c921771eee1d2.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
