### PR TITLE
Lower minimum Ruby version to 3.2.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,11 +42,13 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
+          - {os: ubuntu-24.04, ruby: '3.2'}
           - {os: ubuntu-24.04, ruby: '3.3'}
           - {os: ubuntu-24.04, ruby: '3.4'}
           - {os: ubuntu-24.04, ruby: '4.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-10.0.5.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-10.1.0.0'}
+          - {os: windows-2025, ruby: '3.2'}
           - {os: windows-2025, ruby: '3.3'}
           - {os: windows-2025, ruby: '3.4'}
           - {os: windows-2025, ruby: '4.0'}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ plugins:
 
 # without excluding the vendor dirs below, rubocop will load all rubocop config files from installed gems ¯\_(ツ)_/¯
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.2
   Include:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'

--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
   spec.authors = ["OpenVox Project"]
   spec.date = "2012-08-17"
   spec.description = <<~EOF


### PR DESCRIPTION
### Short description
Lower the minimum Ruby version to 3.2 to maintain backwards compatibility with OpenVox 8 agents.

This partially reverts the changes in e83c37b57d (#442).

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
