### PR TITLE
Copy input mtime to files generated by puppet generate types

### DIFF
--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -45,11 +45,14 @@ module Puppet
         end
 
         # Determines if the output file is up-to-date with respect to the input file.
+        # Generated files are stamped with their input's mtime, so the output is
+        # up-to-date only on an exact match; an input with older timestamps (e.g.
+        # a module downgrade) also triggers regeneration.
         # @param [String, nil] The path to output to, or nil if determined by input
         # @return [Boolean] Returns true if the output is up-to-date or false if not.
         def up_to_date?(outputdir)
           f = effective_output_path(outputdir)
-          Puppet::FileSystem.exist?(f) && (Puppet::FileSystem.stat(@path) <=> Puppet::FileSystem.stat(f)) <= 0
+          Puppet::FileSystem.exist?(f) && (Puppet::FileSystem.stat(@path) <=> Puppet::FileSystem.stat(f)) == 0
         end
 
         # Gets the filename of the output file.
@@ -240,6 +243,7 @@ module Puppet
             Puppet::FileSystem.open(effective_output_path, nil, 'w:UTF-8') do |file|
               file.write(result)
             end
+            Puppet::FileSystem.touch(effective_output_path, mtime: Puppet::FileSystem.stat(input.path).mtime)
           rescue Exception => e
             @bad_input = true
             Puppet.log_exception(e, _("Failed to generate '%{effective_output_path}': %{message}") % { effective_output_path: effective_output_path, message: e.message })

--- a/spec/unit/face/generate_spec.rb
+++ b/spec/unit/face/generate_spec.rb
@@ -184,26 +184,45 @@ describe Puppet::Face[:generate, :current] do
         # create them (first run)
         genface.types
         stats_before = [Puppet::FileSystem.stat(File.join(outputdir, 'test1.pp')), Puppet::FileSystem.stat(File.join(outputdir, 'test2.pp'))]
-        # fake change in input test1 - sorry about the sleep (which there was a better way to change the modtime
-        sleep(1)
-        Puppet::FileSystem.touch(File.join(m1, 'lib', 'puppet', 'type', 'test1.rb'))
+        # fake change in input test1 by giving it an mtime that differs from its output
+        stale = stats_before[0].mtime + 2
+        File.utime(stale, stale, File.join(m1, 'lib', 'puppet', 'type', 'test1.rb'))
         # generate again
         genface.types
-        # assert that test1 was overwritten (later) but not test2 (same time)
+        # assert that test1 was overwritten (stamped with its input's new mtime) but not test2
         stats_after = [Puppet::FileSystem.stat(File.join(outputdir, 'test1.pp')), Puppet::FileSystem.stat(File.join(outputdir, 'test2.pp'))]
         expect(stats_before[1] <=> stats_after[1]).to be(0)
         expect(stats_before[0] <=> stats_after[0]).to be(-1)
+        expect(stats_after[0].mtime).to eq(Puppet::FileSystem.stat(File.join(m1, 'lib', 'puppet', 'type', 'test1.rb')).mtime)
+      end
+
+      it 'overwrites when an input is older than its output (module downgrade)' do
+        # create them (first run)
+        genface.types
+        output = File.join(outputdir, 'test1.pp')
+        # fake a downgrade: input mtime is older than the generated output
+        older = Puppet::FileSystem.stat(output).mtime - 2
+        File.utime(older, older, File.join(m1, 'lib', 'puppet', 'type', 'test1.rb'))
+        # generate again
+        genface.types
+        # assert that test1 was regenerated and stamped with the older input mtime
+        expect(Puppet::FileSystem.stat(output).mtime).to eq(older)
       end
 
       it 'overwrites all files when called with --force' do
         # create them (first run)
         genface.types
         stats_before = [Puppet::FileSystem.stat(File.join(outputdir, 'test1.pp')), Puppet::FileSystem.stat(File.join(outputdir, 'test2.pp'))]
-        # generate again
-        sleep(1) # sorry, if there is no delay the stats will be the same
+        # corrupt the outputs to prove --force rewrites them; mtimes are copied
+        # from the unchanged inputs, so content is the rewrite detector
+        File.write(File.join(outputdir, 'test1.pp'), '# stale sentinel')
+        File.write(File.join(outputdir, 'test2.pp'), '# stale sentinel')
         genface.types(:force => true)
+        expect(File.read(File.join(outputdir, 'test1.pp'))).not_to include('sentinel')
+        expect(File.read(File.join(outputdir, 'test2.pp'))).not_to include('sentinel')
+        # regenerated outputs are re-stamped with their inputs' unchanged mtimes
         stats_after = [Puppet::FileSystem.stat(File.join(outputdir, 'test1.pp')), Puppet::FileSystem.stat(File.join(outputdir, 'test2.pp'))]
-        expect(stats_before <=> stats_after).to be(-1)
+        expect(stats_before <=> stats_after).to be(0)
       end
 
       it 'removes previously generated files from output when there is no input for it' do


### PR DESCRIPTION
### Short description
Generated type outputs are now stamped with their input file's `mtime`, and `up_to_date?` requires an exact `mtime` match instead of `input <= output`. Previously an input older than its output was considered up to date, so installing a module release with older timestamps (a downgrade, or a timestamp-preserving install) never regenerated its types without `--force`.

The exact-match comparison also removes the wall-clock dependence that made the generate face specs flaky on CI: outputs no longer carry the generation time, so the specs set input mtimes explicitly instead of sleeping across timestamp boundaries. Both `sleep(1)` calls are gone, the `--force` spec detects rewrites by content (mtimes are intentionally preserved now), and a new spec covers the downgrade case.

Ported from puppetlabs/puppet#9206 from @ekohl with tests updated by Claude Code.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
