### PR TITLE
Update ca_last_update/crl_last_update on HTTP 304

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -121,6 +121,10 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CA certificate is unmodified, using existing CA certificate"))
+        # 304 confirms the local CA is current, so reset the TTL.
+        # Otherwise ca_last_update (backed by ca.pem mtime) never advances
+        # past the initial download and needs_refresh? triggers on every run.
+        @cert_provider.ca_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CA certificate, using existing CA certificate: %{message}") % { message: e.message })
       end
@@ -219,6 +223,8 @@ class Puppet::SSL::StateMachine
     rescue Puppet::HTTP::ResponseError => e
       if e.response.code == 304
         Puppet.info(_("CRL is unmodified, using existing CRL"))
+        # 304 confirms the local CRL is current, so reset the TTL.
+        @cert_provider.crl_last_update = Time.now
       else
         Puppet.info(_("Failed to refresh CRL, using existing CRL: %{message}") % { message: e.message })
       end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -495,6 +495,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         state.next_state
       end
 
+      it 'updates the `last_update` time on 304 Not Modified so ca_refresh_interval is respected' do
+        stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_return(status: 304)
+
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:ca_last_update=).with(be_within(60).of(Time.now))
+
+        state.next_state
+      end
+
       it "does not update the `last_update` time when CA refresh fails" do
         stub_request(:get, %r{puppet-ca/v1/certificate/ca}).to_raise(Errno::ECONNREFUSED)
 
@@ -653,6 +661,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
       it 'updates the `last_update` time' do
         stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 200, body: new_crl_bundle.join)
+
+        expect_any_instance_of(Puppet::X509::CertProvider).to receive(:crl_last_update=).with(be_within(60).of(Time.now))
+
+        state.next_state
+      end
+
+      it 'updates the `last_update` time on 304 Not Modified so crl_refresh_interval is respected' do
+        stub_request(:get, %r{puppet-ca/v1/certificate_revocation_list/ca}).to_return(status: 304)
 
         expect_any_instance_of(Puppet::X509::CertProvider).to receive(:crl_last_update=).with(be_within(60).of(Time.now))
 


### PR DESCRIPTION
A 304 Not Modified response confirms the local CA certificate or CRL is current, so the refresh-interval TTL should be reset. Previously ca_last_update (backed by ca.pem's mtime) never advanced past the initial download in steady state, so every agent run saw a stale mtime and re-issued the conditional GET regardless of ca_refresh_interval.

The CRL path had the same structural issue but was latent because CRL endpoints typically respond 200 often enough that save_crls bumps the mtime naturally. Fix it for symmetry.

Fixes #435

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
