### PR TITLE
Update acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,15 +12,11 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.8')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION' || "~> 4.0"])
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1.0")
-gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
-gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
-gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 1.0")
-gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || "~> 0.5")
-gem "beaker-gke", *location_for(ENV['BEAKER_GKE_VERSION'] || "~> 0.0.3")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 7.6')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION' || "~> 4.4"])
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 2.1")
+gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 2.2")
+gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || "~> 3.1")
 gem "rake", ">= 12.3.3"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/pre-suite/040_ValidateSignCert.rb
+++ b/acceptance/pre-suite/040_ValidateSignCert.rb
@@ -13,7 +13,7 @@ test_name 'Validate Sign Cert' do
 
   step 'Clear SSL on all hosts'
   hosts.each do |host|
-    ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
+    ssldir = host.puppet['ssldir']
     # preserve permissions for master's ssldir so puppetserver can read it
     on(host, "rm -rf '#{ssldir}/'*")
   end

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -55,7 +55,7 @@ agents.each do |agent|
   step "Modify file to force apply to retrieve file from local clientbucket"
   on(agent, "echo 'This is the modified file contents' > #{target}")
 
-  dir = on(agent, puppet_filebucket("--configprint clientbucketdir")).stdout.chomp
+  dir = agent.puppet('user')['clientbucketdir']
 
   sha256_manifest = %Q|
     filebucket { 'local':

--- a/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
+++ b/acceptance/tests/security/cve-2013-1652_improper_query_params.rb
@@ -17,7 +17,7 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
     agents.each do |agent|
       next if agent['roles'].include?( 'master' )
 
-      certname = on(agent, puppet('agent', "--configprint certname")).stdout.chomp
+      certname = agent.puppet['certname']
 
       payload = "https://#{master}:8140/puppet/v3/catalog/#{certname}" +
                 "?environment=production&use_node=" +
@@ -25,8 +25,8 @@ test_name "CVE 2013-1652 Improper query parameter validation" do
                 "name:%20#{master}%0A%20%20classes:%20\[\]%0A%20%20" +
                 "parameters:%20%7B%7D%0A%20%20facts:%20%7B%7D"
 
-      cert_path = on(agent, puppet('agent', "--configprint hostcert")).stdout.chomp
-      key_path = on(agent, puppet('agent', "--configprint hostprivkey")).stdout.chomp
+      cert_path = agent.puppet['hostcert']
+      key_path  = agent.puppet['hostprivkey']
       curl_base = "curl --tlsv1 -g --cert \"#{cert_path}\" --key \"#{key_path}\" -k -H 'Accept: application/json'"
 
       curl_call =  "#{curl_base} '#{payload}'"

--- a/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
+++ b/acceptance/tests/security/cve-2013-1652_poison_other_node_cache.rb
@@ -14,12 +14,9 @@ test_name "CVE 2013-1652 Poison node cache" do
     # Ensure agent has a signed cert
     on master, puppet('agent', '-t' )
 
-    certname = on(
-      master, puppet('agent', "--configprint certname")).stdout.chomp
-    cert_path = on(
-      master, puppet('agent', "--configprint hostcert")).stdout.chomp
-    key_path = on(
-      master, puppet('agent', "--configprint hostprivkey")).stdout.chomp
+    certname  = master.puppet['certname']
+    cert_path = master.puppet['hostcert']
+    key_path  = master.puppet['hostprivkey']
 
     curl_base = "curl --tlsv1 -g --cert \"#{cert_path}\" " +
                 "--key \"#{key_path}\" -k -H 'Accept: application/json'"

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -112,7 +112,7 @@ begin
         agents.each do |agent|
 
           step "capture the existing ssldir, in case the default package puppet.conf sets it within vardir (rhel...)"
-          agent_ssldir = on(agent, puppet('agent --configprint ssldir')).stdout.chomp
+          agent_ssldir = agent.puppet['ssldir']
 
           on(agent, puppet('agent',
                            "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\" ",

--- a/packaging/acceptance/Gemfile
+++ b/packaging/acceptance/Gemfile
@@ -12,13 +12,10 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 6.8")
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4")
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1")
-gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
-gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
-gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 1")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 7.6")
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4.4")
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 2.1")
+gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 2.2")
 gem "rake", ">= 12.3.3"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/packaging/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/packaging/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -90,7 +90,7 @@ end
 
 step 'test configprint outputs'
 agents.each do |agent|
-  on(agent, puppet_agent('--configprint all')) do |result|
+  on(agent, puppet('config print --section=agent')) do |result|
     config_options(agent).select {|v| !v[:not_puppet_config] }.each do |config_option|
       assert_match("#{config_option[:name]} = #{config_option[:expected]}", result.stdout)
     end


### PR DESCRIPTION
### Short description

This changeset moves the acceptance tests to run under Beaker 7.6.0, and fixes tests that were failing due to the removal of the `--configprint` flag in PR #374. 

Passing test suite:

https://github.com/Sharpie/openvox/actions/runs/29256165305

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
