### PR TITLE
Update JRuby 10.0 test cell to 10.0.6.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.3'}
           - {os: ubuntu-24.04, ruby: '3.4'}
           - {os: ubuntu-24.04, ruby: '4.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-10.0.5.0'}
+          - {os: ubuntu-24.04, ruby: 'jruby-10.0.6.0'}
           - {os: ubuntu-24.04, ruby: 'jruby-10.1.0.0'}
           - {os: windows-2025, ruby: '3.2'}
           - {os: windows-2025, ruby: '3.3'}


### PR DESCRIPTION
### Short description

This change moves the JRuby 10.0 tests from using 10.0.5.0 to 10.0.6.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
