### PR TITLE
acceptance: Fix hashrocket spacing in Hiera tests

### DIFF
--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -326,16 +326,16 @@ with_puppet_running_on master, @master_opts, @coderoot do
 
     step "Verifying hiera() call #2."
     assert_match(
-      /#{@h_h_call}.*\"#{@k3}\"=>\"#{@hval3p}\"/,
+      /#{@h_h_call}.*\"#{@k3}\" => \"#{@hval3p}\"/,
       result,
-      "#{@h_h_call} failed. Expected: '\"#{@k3}\"=>\"#{@hval3p}\"'"
+      "#{@h_h_call} failed. Expected: '\"#{@k3}\" => \"#{@hval3p}\"'"
     )
 
     step "Verifying hiera() call #3."
     assert_match(
-      /#{@h_h_call}.*\"#{@k2}\"=>\"#{@hval2p}\"/,
+      /#{@h_h_call}.*\"#{@k2}\" => \"#{@hval2p}\"/,
       result,
-      "#{@h_h_call} failed. Expected: '\"#{@k2}\"=>\"#{@hval2p}\"'"
+      "#{@h_h_call} failed. Expected: '\"#{@k2}\" => \"#{@hval2p}\"'"
     )
 
     step "Verifying hiera() call #4."
@@ -361,23 +361,23 @@ with_puppet_running_on master, @master_opts, @coderoot do
 
     step "Verifying hiera_hash() call. #1"
     assert_match(
-      /#{@hh_h_call}:.*\"#{@k3}\"=>\"#{@hval3p}\"/,
+      /#{@hh_h_call}:.*\"#{@k3}\" => \"#{@hval3p}\"/,
       result,
-      "#{@hh_h_call} failed. Expected: '\"#{@k3}\"=>\"#{@hval3p}\"'"
+      "#{@hh_h_call} failed. Expected: '\"#{@k3}\" => \"#{@hval3p}\"'"
     )
 
     step "Verifying hiera_hash() call. #2"
     assert_match(
-      /#{@hh_h_call}:.*\"#{@k2}\"=>\"#{@hval2p}\"/,
+      /#{@hh_h_call}:.*\"#{@k2}\" => \"#{@hval2p}\"/,
       result,
-      "#{@hh_h_call} failed. Expected: '\"#{@k2}\"=>\"#{@hval2p}\"'"
+      "#{@hh_h_call} failed. Expected: '\"#{@k2}\" => \"#{@hval2p}\"'"
     )
 
     step "Verifying hiera_hash() call. #3"
     assert_match(
-      /#{@hh_h_call}:.*\"#{@k1}\"=>\"#{@hval1os}\"/,
+      /#{@hh_h_call}:.*\"#{@k1}\" => \"#{@hval1os}\"/,
       result,
-      "#{@hh_h_call} failed.  Expected: '\"#{@k1}\"=>\"#{@hval1os}\"'"
+      "#{@hh_h_call} failed.  Expected: '\"#{@k1}\" => \"#{@hval1os}\"'"
     )
 
     r2 = on(agent, "cat #{resultdir}/mod_default")


### PR DESCRIPTION
### Short description

Ruby 3.4 brings a change to how `Hash#inspect` stringifies data:

  https://bugs.ruby-lang.org/issues/20433

This commit updates the `hiera_in_templates.rb` acceptance test to expect the new `{a => b}` output instead of the older, compact, `{a=>b}` output.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
