### PR TITLE
Set `PUPPET_EXTRA_OPTS` variable to empty

### DIFF
--- a/ext/redhat/client.sysconfig
+++ b/ext/redhat/client.sysconfig
@@ -1,2 +1,3 @@
 # You may specify parameters to the puppet client here
 #PUPPET_EXTRA_OPTS=--waitforcert=500
+PUPPET_EXTRA_OPTS=


### PR DESCRIPTION
- this will silence the systemd warning "(puppet)[17215]: puppet.service: Referenced but unset environment variable evaluates to an empty string: PUPPET_EXTRA_OPTS"

### Short description
avoid systemd warning

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
