### PR TITLE
Replace deprecated `--force-yes` `apt-get` option

### DIFF
--- a/acceptance/tests/provider/package/apt_install_package_with_range.rb
+++ b/acceptance/tests/provider/package/apt_install_package_with_range.rb
@@ -20,7 +20,7 @@ test_name "apt can install range if package is not installed" do
     on(agent, 'apt-get update')
 
     teardown do
-      package_absent(agent, package, '--force-yes')
+      package_absent(agent, package, '--allow-downgrades')
       file_manifest = resource_manifest('file', '/etc/apt/sources.list.d/tmp.list', ensure: 'absent')
       apply_manifest_on(agent, file_manifest)
       on(agent, 'rm -rf /tmp/debian-repo')

--- a/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
+++ b/acceptance/tests/provider/package/dpkg_hold_true_package_is_latest.rb
@@ -12,7 +12,7 @@ test_name "dpkg ensure hold package is latest installed" do
 
   agents.each do |agent|
     teardown do
-      package_absent(agent, package, '--force-yes')
+      package_absent(agent, package, '--allow-downgrades')
     end
   end
 

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -149,9 +149,9 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     when true, false, Symbol
       # pass
     else
-      # Add the package version and --force-yes option
+      # Add the package version and --allow-downgrades option (it was --force-yes before)
       str += "=#{should}"
-      cmd << "--force-yes"
+      cmd << "--allow-downgrades"
     end
 
     cmd += install_options if @resource[:install_options]

--- a/lib/puppet/provider/package/aptitude.rb
+++ b/lib/puppet/provider/package/aptitude.rb
@@ -14,7 +14,6 @@ Puppet::Type.type(:package).provide :aptitude, :parent => :apt, :source => :dpkg
     args.flatten!
     # Apparently aptitude hasn't always supported a -q flag.
     args.delete("-q") if args.include?("-q")
-    args.delete("--force-yes") if args.include?("--force-yes")
     output = aptitude(*args)
 
     # Yay, stupid aptitude doesn't throw an error when the package is missing.

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -222,10 +222,10 @@ Version table:
       provider.install
     end
 
-    it "should use --force-yes if a package version is specified" do
+    it "should use --allow-downgrades if a package version is specified" do
       resource[:ensure] = '1.0'
       expect(provider).to receive(:aptget) do |*command|
-        expect(command).to include("--force-yes")
+        expect(command).to include("--allow-downgrades")
       end
       expect(provider).to receive(:properties).and_return({:mark => :none})
 


### PR DESCRIPTION
### Short description
The `--force-yes` apt-get CLI option was deprecated while ago. There are multiple --allow-* options to replace it with. I guess, only --allow-downgrades really makes sense here.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
