### PR TITLE
refactor(service/systemd): remove Debian SysVInit compatibility fallback

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -83,17 +83,6 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     systemctl_change_enable(:disable)
   end
 
-  def get_start_link_count
-    # Start links don't include '.service'. Just search for the service name.
-    if @resource[:name] =~ /\.service/
-      link_name = @resource[:name].split('.')[0]
-    else
-      link_name = @resource[:name]
-    end
-
-    Dir.glob("/etc/rc*.d/S??#{link_name}").length
-  end
-
   def cached_enabled?
     return @cached_enabled if @cached_enabled
 
@@ -118,37 +107,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     return :false if output == 'indirect'
     return :true if code == 0
 
-    if output.empty? && (code > 0) && Puppet.runtime[:facter].value('os.family').casecmp('debian').zero?
-      ret = debian_enabled?
-      return ret if ret
-    end
-
     :false
-  end
-
-  # This method is required for Debian systems due to the way the SysVInit-Systemd
-  # compatibility layer works. When we are trying to manage a service which does not
-  # have a Systemd unit file, we need to go through the old init script to determine
-  # whether it is enabled or not. See PUP-5016 for more details.
-  #
-  def debian_enabled?
-    status = execute(["/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start"], :failonfail => false)
-    if [104, 106].include?(status.exitstatus)
-      :true
-    elsif [101, 105].include?(status.exitstatus)
-      # 101 is action not allowed, which means we have to do the check manually.
-      # 105 is unknown, which generally means the initscript does not support query
-      # The debian policy states that the initscript should support methods of query
-      # For those that do not, perform the checks manually
-      # http://www.debian.org/doc/debian-policy/ch-opersys.html
-      if get_start_link_count >= 4
-        :true
-      else
-        :false
-      end
-    else
-      :false
-    end
   end
 
   # Define the daemon_reload? function to check if the unit is requiring to trigger a "systemctl daemon-reload"

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -340,13 +340,12 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
       expect(provider.enabled?).to eq(:mask)
     end
 
-    it "should consider nonexistent services to be disabled" do
+    it "should consider nonexistent services to be disabled and not fall back to the Debian SysVInit invoke-rc.d probe" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist'))
       allow(Facter).to receive(:value).with('os.family').and_return('debian')
       expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'doesnotexist'], {:failonfail => false})
                             .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
-      expect(provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], {:failonfail => false})
-                            .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
+      expect(provider).not_to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], {:failonfail => false})
 
       expect(provider.enabled?).to be(:false)
     end
@@ -457,32 +456,6 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     end
   end
 
-  describe "#debian_enabled?" do
-    [104, 106].each do |status|
-      it "should return true when invoke-rc.d returns #{status}" do
-        provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-        allow(provider).to receive(:execute).and_return(Puppet::Util::Execution::ProcessOutput.new('', status))
-        expect(provider.debian_enabled?).to eq(:true)
-      end
-    end
-
-    [101, 105].each do |status|
-      it "should return true when status is #{status} and there are at least 4 start links" do
-        provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-        allow(provider).to receive(:execute).and_return(Puppet::Util::Execution::ProcessOutput.new('', status))
-        expect(provider).to receive(:get_start_link_count).and_return(4)
-        expect(provider.debian_enabled?).to eq(:true)
-      end
-
-      it "should return false when status is #{status} and there are less than 4 start links" do
-        provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-        allow(provider).to receive(:execute).and_return(Puppet::Util::Execution::ProcessOutput.new('', status))
-        expect(provider).to receive(:get_start_link_count).and_return(1)
-        expect(provider.debian_enabled?).to eq(:false)
-      end
-    end
-  end
-
   describe "#insync_enabled?" do
     let(:provider) do
       provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
@@ -563,20 +536,6 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
         expect(Puppet).not_to receive(:debug)
         provider.enabled_insync?(:true)
       end
-    end
-  end
-
-  describe "#get_start_link_count" do
-    it "should strip the '.service' from the search if present in the resource name" do
-      provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(Dir).to receive(:glob).with("/etc/rc*.d/S??sshd").and_return(['files'])
-      provider.get_start_link_count
-    end
-
-    it "should use the full service name if it does not include '.service'" do
-      provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(Dir).to receive(:glob).with("/etc/rc*.d/S??sshd").and_return(['files'])
-      provider.get_start_link_count
     end
   end
 


### PR DESCRIPTION
The systemd provider no longer falls back to invoke-rc.d/init script inspection to determine whether a service is enabled.

### Short description
The systemd provider no longer falls back to invoke-rc.d/init script inspection to determine whether a service is enabled.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
