### PR TITLE
User resource pw provider: Switches a couple commands to the safer array syntax

### DIFF
--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   # use pw to update password hash
   def password=(cryptopw)
     Puppet.debug "change password for user '#{@resource[:name]}' method called with hash [redacted]"
-    stdin, _, _ = Open3.popen3("pw user mod #{@resource[:name]} -H 0")
+    stdin, _, _ = Open3.popen3('pw', 'user', 'mod', @resource[:name], '-H', '0')
     stdin.puts(cryptopw)
     stdin.close
     Puppet.debug "finished password for user '#{@resource[:name]}' method called with hash [redacted]"
@@ -79,7 +79,7 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   # get password from /etc/master.passwd
   def password
     Puppet.debug "checking password for user '#{@resource[:name]}' method called"
-    current_passline = `getent passwd #{@resource[:name]}`
+    current_passline, _ = Open3.capture2('getent', 'passwd', @resource[:name])
     current_password = current_passline.chomp.split(':')[1] if current_passline
     Puppet.debug "finished password for user '#{@resource[:name]}' method called : [redacted]"
     current_password


### PR DESCRIPTION
Changes no behaviour, just swaps syntax.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
