### PR TITLE
Validate that the catalog is compiled for this node

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -253,7 +253,8 @@ class Puppet::Configurer
 
   def prepare_and_retrieve_catalog(cached_catalog, facts, options, query_options)
     # set report host name now that we have the fact
-    options[:report].host = Puppet[:node_name_value]
+    node_name = Puppet[:node_name_value]
+    options[:report].host = node_name
 
     query_options[:transaction_uuid] = @transaction_uuid
     query_options[:job_id] = @job_id
@@ -270,6 +271,11 @@ class Puppet::Configurer
       catalog = retrieve_catalog(facts, query_options)
       Puppet.err _("Could not retrieve catalog; skipping run") unless catalog
     end
+
+    if catalog.name != node_name
+      Puppet.err _("Catalog name '#{catalog.name}' does not match this node's certname '#{node_name}'")
+    end
+
     catalog
   end
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -240,7 +240,7 @@ describe Puppet::Configurer do
       Puppet[:number_of_facts_soft_limit] = 1
       Puppet[:payload_soft_limit] = 0
 
-      facts.values = { 
+      facts.values = {
         'processors' => {
           'cores' => 1,
           'count' => 2,
@@ -251,13 +251,13 @@ describe Puppet::Configurer do
             "CPU1 @ 2.80GHz",
             "CPU1 @ 2.80GHz",
             "CPU1 @ 2.80GHz",
-            { 
+            {
               'processors' => {
                 'cores' => [1,2]
               }
             }
           ],
-          'physicalcount' => 4 
+          'physicalcount' => 4
         }
       }
       Puppet::Node::Facts.indirection.save(facts)
@@ -329,6 +329,16 @@ describe Puppet::Configurer do
 
       expect(Puppet).to receive(:err).with("Could not retrieve catalog; skipping run")
 
+      configurer.run
+    end
+
+    it "should log a failure and do nothing if the catalog node name doesn't match the current node name" do
+      cached_catalog = Puppet::Resource::Catalog.new('bananas', Puppet::Node::Environment.remote(Puppet[:environment].to_sym))
+
+      expects_fallback_to_cached_catalog(cached_catalog)
+
+      allow(Puppet).to receive(:err)
+      expect(Puppet).to receive(:err).with("Catalog name 'bananas' does not match this node's certname '#{node_name}'")
       configurer.run
     end
 


### PR DESCRIPTION
There are a few odd circumstances in which the catalog might be for the
wrong node, for example if an image is cloned and the cached catalog
isn't cleaned up. Or maybe even if there's a misconfiguration in a
load balancer or something.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
