### PR TITLE
Improve manpage reproducibility

### DIFF
--- a/rakelib/manpages.rake
+++ b/rakelib/manpages.rake
@@ -15,7 +15,7 @@ task :gen_manpages do
   ronn_args = '--manual="OpenVox manual" --organization="Vox Pupuli" --roff'
 
   unless ENV['SOURCE_DATE_EPOCH'].nil?
-    source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d')
+    source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i, in: 'UTC').strftime('%Y-%m-%d')
     ronn_args += " --date=#{source_date}"
   end
 


### PR DESCRIPTION
Always treat SOURCHE_DATE_EPOCH as a UTC timestamp, to prevent variability introduced by the environment's timezone setting.

This is one of the patches Debian has been carrying in its `puppet-agent` package. The PR is still rotting in the previous upstream's repo at https://github.com/puppetlabs/puppet/pull/9548