### PR TITLE
Update URLs in default config files

### DIFF
--- a/conf/environment.conf
+++ b/conf/environment.conf
@@ -1,6 +1,6 @@
 # Each environment can have an environment.conf file. Its settings will only
 # affect its own environment. See docs for more info:
-# https://puppet.com/docs/puppet/latest/config_file_environment.html
+# https://docs.openvoxproject.org/openvox/latest/config_file_environment.html
 
 # Any unspecified settings use default values; some of those defaults are based
 # on puppet.conf settings.

--- a/conf/fileserver.conf
+++ b/conf/fileserver.conf
@@ -29,4 +29,4 @@
 # The ability to set permissions - for example, using the allow, allow_ip, or
 # deny directives - has been removed from fileserver.conf. Instead, you can
 # control file access in Puppet Server's auth.conf file. See the documentation
-# at https://puppet.com/docs/puppetserver/latest/config_file_auth.html.
+# at https://docs.openvoxproject.org/openvox/latest/config_file_fileserver.html.

--- a/conf/puppet.conf
+++ b/conf/puppet.conf
@@ -1,6 +1,6 @@
 # This file can be used to override the default puppet settings.
 # See the following links for more details on what settings are available:
-# - https://puppet.com/docs/puppet/latest/config_important_settings.html
-# - https://puppet.com/docs/puppet/latest/config_about_settings.html
-# - https://puppet.com/docs/puppet/latest/config_file_main.html
-# - https://puppet.com/docs/puppet/latest/configuration.html
+# - https://docs.openvoxproject.org/openvox/latest/config_important_settings.html
+# - https://docs.openvoxproject.org/openvox/latest/config_about_settings.html
+# - https://docs.openvoxproject.org/openvox/latest/config_file_main.html
+# - https://docs.openvoxproject.org/openvox/latest/configuration.html


### PR DESCRIPTION
Now, arguably there are a lot more dead `puppet.com` URLs everywhere in the source but the config files are arguably where most users will have a look, so, it's a start?