### PR TITLE
Remove bashism from pre/post-install scripts

### DIFF
--- a/packaging/configs/components/puppet.rb
+++ b/packaging/configs/components/puppet.rb
@@ -256,15 +256,15 @@ component "puppet" do |pkg, settings, platform|
 # can drop them back in place if the package manager
 # tries to remove it.
 if [ -e #{old_hiera} ]; then
-  #{cp_cmd} #{old_hiera}{,.pkg-old}
+  #{cp_cmd} #{old_hiera} #{old_hiera}.pkg-old
   touch #{rmv_hiera}
 fi
 if [ -e #{cnf_hiera} ]; then
-  #{cp_cmd} #{cnf_hiera}{,.pkg-old}
+  #{cp_cmd} #{cnf_hiera} #{cnf_hiera}.pkg-old
   touch #{rmv_hiera}
 fi
 if [ -e #{env_hiera} ]; then
-  #{cp_cmd} #{env_hiera}{,.pkg-old}
+  #{cp_cmd} #{env_hiera} #{env_hiera}.pkg-old
   touch #{rmv_hiera}
 fi
 PREINST
@@ -281,13 +281,13 @@ fi
 
 # Restore the old hiera, if it existed
 if [ -e #{old_hiera}.pkg-old ]; then
-  mv #{old_hiera}{.pkg-old,}
+  mv #{old_hiera}.pkg-old #{old_hiera}
 fi
 if [ -e #{cnf_hiera}.pkg-old ]; then
-  mv #{cnf_hiera}{.pkg-old,}
+  mv #{cnf_hiera}.pkg-old #{cnf_hiera}
 fi
 if [ -e #{env_hiera}.pkg-old ]; then
-  mv #{env_hiera}{.pkg-old,}
+  mv #{env_hiera}.pkg-old #{env_hiera}
 fi
 
 POSTINST


### PR DESCRIPTION
### Short description

Brace-expansions are a bashism which is not supported by all POSIX shells.

Replace it to make the scripts work correctly also on systems where `/bin/sh` is not linked to bash (or ksh for that matter).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
