### PR TITLE
Add acceptance test for agent run without `/etc/hosts`

### DIFF
--- a/packaging/acceptance/tests/agent_runs_without_hosts_file.rb
+++ b/packaging/acceptance/tests/agent_runs_without_hosts_file.rb
@@ -1,0 +1,29 @@
+test_name 'puppet agent runs without /etc/hosts' do
+  tag 'audit:high',
+      'audit:acceptance'
+
+  agents.each do |agent|
+    skip_test('This test only applies to Linux agents') if agent['platform'] =~ /windows/
+
+    hosts_file = '/etc/hosts'
+    backup_dir = agent.tmpdir('missing_hosts_file')
+    backup_hosts = File.join(backup_dir, 'hosts')
+
+    teardown do
+      on(agent, "if test -f #{backup_hosts}; then cp #{backup_hosts} #{hosts_file}; fi")
+    end
+
+    step 'Back up /etc/hosts and remove it' do
+      on(agent, "mkdir -p #{backup_dir}")
+      on(agent, "if test -f #{hosts_file}; then cp #{hosts_file} #{backup_hosts}; fi")
+      on(agent, "rm -f #{hosts_file}")
+      on(agent, "test ! -e #{hosts_file}")
+    end
+
+    step 'Run puppet agent without /etc/hosts' do
+      on(agent, puppet('agent --test'), acceptable_exit_codes: [0, 2]) do |result|
+        assert_match(/Applied catalog/, result.stdout)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Short description

I found that PE puppet agent fails when run on a machine that lacks `/etc/hosts`. Trying to see if OpenVox has the same problem.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
