### PR TITLE
Exclude gettext interpolation from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -386,3 +386,8 @@ Style/OptionalArguments:
     # Moving optional arguments to the end of the method signature would be
     # a breaking change.
     - 'lib/puppet/util/windows/principal.rb'
+
+# Interpolated _() strings are all over the codebase.
+# This would be incredibly noisy, and FastGettext handles interpolation just fine.
+I18n/GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false


### PR DESCRIPTION
A huge amount of the translated messages are interpolated. See this pot
file from back when the codebase was actually internationalized for an
idea of that scope.

https://github.com/puppetlabs/puppet/blob/fdbd2d49f8afc0aeec54cca848afb98eb3449e19/locales/puppet.pot

Signed-off-by: Ben Ford <binford2k@overlookinfratech.com>

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
