### PR TITLE
openfact: Allow 6.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout current PR
         uses: actions/checkout@v6
 
-      - name: Install ruby version ${{ matrix.cfg.ruby }}
+      - name: Install Ruby version ${{ matrix.cfg.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rake ${{ matrix.cfg.check }}
 
   rspec_tests:
-    name: ${{ matrix.cfg.os }}(ruby ${{ matrix.cfg.ruby }} / OpenFact ${{ matrix.cfg.openfact }})
+    name: ${{ matrix.cfg.os }}(Ruby ${{ matrix.cfg.ruby }} / OpenFact ${{ matrix.cfg.openfact }})
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout current PR
         uses: actions/checkout@v6
 
-      - name: Install ruby version ${{ matrix.cfg.ruby }}
+      - name: Install Ruby version ${{ matrix.cfg.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.cfg.ruby }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,22 +37,29 @@ jobs:
         run: bundle exec rake ${{ matrix.cfg.check }}
 
   rspec_tests:
-    name: ${{ matrix.cfg.os }}(ruby ${{ matrix.cfg.ruby }})
+    name: ${{ matrix.cfg.os }}(ruby ${{ matrix.cfg.ruby }} / OpenFact ${{ matrix.cfg.openfact }})
     strategy:
       fail-fast: false
       matrix:
         cfg:
-          - {os: ubuntu-24.04, ruby: '3.2'}
-          - {os: ubuntu-24.04, ruby: '3.3'}
-          - {os: ubuntu-24.04, ruby: '3.4'}
-          - {os: ubuntu-24.04, ruby: '4.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.8.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.14.0'}
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.15'}
-          - {os: windows-2025, ruby: '3.2'}
-          - {os: windows-2025, ruby: '3.3'}
-          - {os: windows-2025, ruby: '3.4'}
-          - {os: windows-2025, ruby: '4.0'}
+          # we default to openfact 5, because that's what we package.
+          # But we want to stay compatible to openfact 6, to make upgrades easier
+          - {os: ubuntu-24.04, ruby: '3.2', openfact: '~> 6.0' }
+          - {os: ubuntu-24.04, ruby: '3.2', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: '3.3', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: '3.4', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: '4.0', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: 'jruby-9.4.8.0', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: 'jruby-9.4.14.0', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0'}
+          - {os: windows-2025, ruby: '3.2', openfact: '~> 6.0' }
+          - {os: windows-2025, ruby: '3.2', openfact: '~> 5.0' }
+          - {os: windows-2025, ruby: '3.3', openfact: '~> 5.0' }
+          - {os: windows-2025, ruby: '3.4', openfact: '~> 5.0' }
+          - {os: windows-2025, ruby: '4.0', openfact: '~> 5.0' }
+    env:
+      OPENFACT_LOCATION: ${{ matrix.cfg.openfact }}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 # the runtime_dependencies in openvox.gemspec match the runtime dependencies here
 # (like openfact, semantic_puppet, and puppet-resource_api)
 
-gem "openfact", *location_for(ENV['OPENFACT_LOCATION'] || ["~> 5.0"])
+gem "openfact", *location_for(ENV['OPENFACT_LOCATION'] || [">= 5.0", "< 7"])
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
 gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 2.0"])
 # Need to update the openssl gem on MacOS to avoid SSL errors.

--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('fiddle', '~> 1.1')
   spec.add_runtime_dependency('getoptlong', '~> 0.2.0')
   spec.add_runtime_dependency('locale', '~> 2.1')
-  spec.add_runtime_dependency('openfact', '~> 5.0')
+  spec.add_runtime_dependency('openfact', '>= 5.0', '< 7')
   spec.add_runtime_dependency('ostruct', '>= 0.5.5', '< 0.7')
   spec.add_runtime_dependency('puppet-resource_api', '~> 2.0')
   spec.add_runtime_dependency('racc', '~> 1.5')


### PR DESCRIPTION
This enables people to test their openvox 8 in CI with openfact 6. openfact 6 will be bundled in openvox 9 packages only.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
