### PR TITLE
Add man page validation to CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,30 @@ env:
   BUNDLE_SET: "without packaging documentation release"
 
 jobs:
+  validate_manpages:
+    name: Validate man pages
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # `man` exits 0 even when groff reports problems, so treat any stderr
+      # output as a failure. Unlike the equivalent check in openfact, this only
+      # inspects stderr (some pages legitimately contain the word "warning")
+      # and uses a wide MANWIDTH (some pages contain unbreakable tokens longer
+      # than 80 columns, such as long URLs and the `ciphers` default value,
+      # which trigger unfixable "cannot break line" warnings at narrower widths).
+      - name: Validate man pages with groff
+        run: |
+          status=0
+          for f in man/man5/*.5 man/man8/*.8; do
+            errors=$(LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=1000 man --warnings -E UTF-8 -l -Tutf8 -Z "$f" 2>&1 >/dev/null)
+            if [ -n "$errors" ]; then
+              echo "$f:"
+              echo "$errors"
+              status=1
+            fi
+          done
+          exit $status
+
   checks:
     name: ${{ matrix.cfg.check }}
     strategy:
@@ -154,6 +178,7 @@ jobs:
   tests:
     if: always()
     needs:
+      - validate_manpages
       - checks
       - rspec_tests
       - rake_checks


### PR DESCRIPTION
### Short description
As suggested in https://github.com/OpenVoxProject/openvox/pull/579#discussion_r3696838750, port the validate_manpage check from openfact's CI: render every man page with groff warnings enabled and fail on any diagnostic output. This catches broken roff from a bad man page regeneration (e.g. undefined macros).

Two deviations from the openfact version, both required for openvox:
- Only stderr is inspected, since some pages legitimately contain the word "warning" in their text (e.g. the disable_warnings setting in puppet.conf(5)), which would false-trip the grep-based check.
- MANWIDTH=1000 instead of 80, since some pages contain unbreakable tokens wider than 80 columns (long URLs, the ciphers default value) that produce unfixable "cannot break line" warnings.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
