### PR TITLE
Change reports default from "store" to "none"

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1418,7 +1418,7 @@ EOT
       :mode => "0750",
       :desc => "The directory in which serialized data is stored, usually in a subdirectory."},
     :reports => {
-      :default    => "store",
+      :default    => "none",
       :desc       => "The list of report handlers to use. When using multiple report handlers,
         their names should be comma-separated, with whitespace allowed. (For example,
         `reports = http, store`.)


### PR DESCRIPTION
### Short description

Prior to this commit, the default for the `reports` setting was `store`, which results in the Server dumping reports submitted by agents to a `.yaml` file under the `reportdir`. The assumption behind this behavior is that some external process is consuming and then removing the saved report files. If no such process exists, report storage by the Server will consume an ever-increasing amount of disk space.

This commit changes to default to "none" as most installations are not running an external process that consumes this data. Sites with external processes that consume stored reports should explicitly configure `reports = store` as part of the setup and integration of those tools with the OpenVox Server.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)