### PR TITLE
Document cross-node read exposure of a central filebucket

### DIFF
--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -104,6 +104,13 @@ Puppet::Type.newtype(:file) do
 
           File { backup => main, }
 
+      > **Note**: A central filebucket is shared by every node that backs up to it,
+        and stored content is addressed only by checksum, with no record of which
+        node submitted it. Treat anything backed up there as readable by every
+        certificate the server's `auth.conf` allows to reach the `file_bucket_file`
+        endpoint, and avoid pointing `backup` at a central filebucket for files whose
+        contents are sensitive. See the `filebucket` resource type for details.
+
       If you are using multiple primary servers, you will want to
       centralize the contents of the filebucket. Either configure your load
       balancer to direct all filebucket traffic to a single primary server, or use

--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -35,6 +35,21 @@ module Puppet
       this will work in a default configuration. If you have a heavily
       restricted OpenVox Server `auth.conf` file, you may need to allow access to the
       `file_bucket_file` endpoint.
+
+      > **Security note**: a central filebucket is shared by every node that backs
+        up to it. Content is addressed purely by checksum, and the service records no
+        association between stored content and the node that submitted it, so a
+        request for `/puppet/v3/file_bucket_file/<digest>/<checksum>` returns the
+        matching content to any client the server's `auth.conf` permits, regardless
+        of which node originally backed that file up. Retrieving content requires
+        knowing the checksum of the exact bytes, so this is not a general-purpose
+        read primitive, but you should treat a central filebucket as readable by
+        every certificate allowed to reach the endpoint and avoid backing up files
+        whose contents are sensitive. Since OpenVox 9 the default `auth.conf` grants
+        agents only the `HEAD` and `PUT` access they need in order to store backups,
+        and restricts `GET` to certificates carrying the `pp_cli_auth` extension. If
+        you restore remotely using some other administrative certificate, add a rule
+        of your own rather than widening the shipped one.
     EOT
 
     newparam(:name) do

--- a/references/type.md
+++ b/references/type.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-built_from_commit: 3d665fe7a4a7dfa794748a310db79025a4d932cc
+built_from_commit: 748a2d11c7785733d0e72b7c4cc606137e07bb8f
 title: Resource Type Reference (Single-Page)
 canonical: "/openvox/latest/type.html"
 toc_levels: 2
@@ -9,7 +9,7 @@ toc: columns
 
 # Resource Type Reference (Single-Page)
 
-> **NOTE:** This page was generated from the OpenVox source code on 2026-08-01 22:13:15 +0000
+> **NOTE:** This page was generated from the OpenVox source code on 2026-08-04 10:46:37 -0500
 
 
 
@@ -802,6 +802,13 @@ in site.pp:
 
     File { backup => main, }
 
+> **Note**: A central filebucket is shared by every node that backs up to it,
+  and stored content is addressed only by checksum, with no record of which
+  node submitted it. Treat anything backed up there as readable by every
+  certificate the server's `auth.conf` allows to reach the `file_bucket_file`
+  endpoint, and avoid pointing `backup` at a central filebucket for files whose
+  contents are sensitive. See the `filebucket` resource type for details.
+
 If you are using multiple primary servers, you will want to
 centralize the contents of the filebucket. Either configure your load
 balancer to direct all filebucket traffic to a single primary server, or use
@@ -1510,6 +1517,21 @@ OpenVox Servers automatically provide the filebucket service, so
 this will work in a default configuration. If you have a heavily
 restricted OpenVox Server `auth.conf` file, you may need to allow access to the
 `file_bucket_file` endpoint.
+
+> **Security note**: a central filebucket is shared by every node that backs
+  up to it. Content is addressed purely by checksum, and the service records no
+  association between stored content and the node that submitted it, so a
+  request for `/puppet/v3/file_bucket_file/<digest>/<checksum>` returns the
+  matching content to any client the server's `auth.conf` permits, regardless
+  of which node originally backed that file up. Retrieving content requires
+  knowing the checksum of the exact bytes, so this is not a general-purpose
+  read primitive, but you should treat a central filebucket as readable by
+  every certificate allowed to reach the endpoint and avoid backing up files
+  whose contents are sensitive. Since OpenVox 9 the default `auth.conf` grants
+  agents only the `HEAD` and `PUT` access they need in order to store backups,
+  and restricts `GET` to certificates carrying the `pp_cli_auth` extension. If
+  you restore remotely using some other administrative certificate, add a rule
+  of your own rather than widening the shipped one.
 
 ### Attributes {#filebucket-attributes}
 

--- a/references/types/file.md
+++ b/references/types/file.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-built_from_commit: 3d665fe7a4a7dfa794748a310db79025a4d932cc
+built_from_commit: 748a2d11c7785733d0e72b7c4cc606137e07bb8f
 title: 'Resource Type: file'
 canonical: "/openvox/latest/types/file.html"
 ---
 
 # Resource Type: file
 
-> **NOTE:** This page was generated from the OpenVox source code on 2026-08-01 22:13:15 +0000
+> **NOTE:** This page was generated from the OpenVox source code on 2026-08-04 10:46:37 -0500
 
 
 
@@ -184,6 +184,13 @@ in site.pp:
     }
 
     File { backup => main, }
+
+> **Note**: A central filebucket is shared by every node that backs up to it,
+  and stored content is addressed only by checksum, with no record of which
+  node submitted it. Treat anything backed up there as readable by every
+  certificate the server's `auth.conf` allows to reach the `file_bucket_file`
+  endpoint, and avoid pointing `backup` at a central filebucket for files whose
+  contents are sensitive. See the `filebucket` resource type for details.
 
 If you are using multiple primary servers, you will want to
 centralize the contents of the filebucket. Either configure your load

--- a/references/types/filebucket.md
+++ b/references/types/filebucket.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-built_from_commit: 3d665fe7a4a7dfa794748a310db79025a4d932cc
+built_from_commit: 748a2d11c7785733d0e72b7c4cc606137e07bb8f
 title: 'Resource Type: filebucket'
 canonical: "/openvox/latest/types/filebucket.html"
 ---
 
 # Resource Type: filebucket
 
-> **NOTE:** This page was generated from the OpenVox source code on 2026-08-01 22:13:15 +0000
+> **NOTE:** This page was generated from the OpenVox source code on 2026-08-04 10:46:37 -0500
 
 
 
@@ -47,6 +47,21 @@ OpenVox Servers automatically provide the filebucket service, so
 this will work in a default configuration. If you have a heavily
 restricted OpenVox Server `auth.conf` file, you may need to allow access to the
 `file_bucket_file` endpoint.
+
+> **Security note**: a central filebucket is shared by every node that backs
+  up to it. Content is addressed purely by checksum, and the service records no
+  association between stored content and the node that submitted it, so a
+  request for `/puppet/v3/file_bucket_file/<digest>/<checksum>` returns the
+  matching content to any client the server's `auth.conf` permits, regardless
+  of which node originally backed that file up. Retrieving content requires
+  knowing the checksum of the exact bytes, so this is not a general-purpose
+  read primitive, but you should treat a central filebucket as readable by
+  every certificate allowed to reach the endpoint and avoid backing up files
+  whose contents are sensitive. Since OpenVox 9 the default `auth.conf` grants
+  agents only the `HEAD` and `PUT` access they need in order to store backups,
+  and restricts `GET` to certificates carrying the `pp_cli_auth` extension. If
+  you restore remotely using some other administrative certificate, add a rule
+  of your own rather than widening the shipped one.
 
 ### Attributes {#filebucket-attributes}
 


### PR DESCRIPTION
### Short description
A central filebucket is shared by every node that backs up to it. Content is addressed purely by checksum, and the service records no association between stored content and the node that submitted it, so any client permitted to GET the file_bucket_file endpoint can retrieve content backed up by any other node. Retrieval requires knowing the checksum of the exact bytes, so this is not a general-purpose read primitive, but it is not the per-node isolation that the rest of the default auth.conf rules imply.

Note this in the filebucket type documentation, including the OpenVox 9 default auth.conf behavior that grants agents only the HEAD and PUT access they need to store backups, and add a pointer from the file type's backup parameter.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
