### PR TITLE
CI: Drop old jruby versions & Fix openfact version for jruby-9.4.15

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,8 +49,6 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.3', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: '3.4', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: '4.0', openfact: '~> 5.0' }
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.8.0', openfact: '~> 5.0' }
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.14.0', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0'}
           - {os: windows-2025, ruby: '3.2', openfact: '~> 6.0' }

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.3', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: '3.4', openfact: '~> 5.0' }
           - {os: ubuntu-24.04, ruby: '4.0', openfact: '~> 5.0' }
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0' }
+          - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 6.0' }
           - {os: ubuntu-24.04, ruby: 'jruby-9.4.15', openfact: '~> 5.0'}
           - {os: windows-2025, ruby: '3.2', openfact: '~> 6.0' }
           - {os: windows-2025, ruby: '3.2', openfact: '~> 5.0' }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
