### PR TITLE
Update vendored modules to latest versions

### DIFF
--- a/packaging/configs/components/module-puppetlabs-augeas_core.json
+++ b/packaging/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-augeas_core.git","ref":"refs/tags/v1.5.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-augeas_core.git","ref":"refs/tags/v2.0.1"}

--- a/packaging/configs/components/module-puppetlabs-cron_core.json
+++ b/packaging/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-cron_core.git","ref":"refs/tags/v1.3.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-cron_core.git","ref":"refs/tags/v2.0.2"}

--- a/packaging/configs/components/module-puppetlabs-host_core.json
+++ b/packaging/configs/components/module-puppetlabs-host_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-host_core.git","ref":"refs/tags/v1.3.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-host_core.git","ref":"refs/tags/v2.0.1"}

--- a/packaging/configs/components/module-puppetlabs-scheduled_task.json
+++ b/packaging/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-scheduled_task.git","ref":"v4.0.3"}
+{"url":"https://github.com/openvoxproject/puppetlabs-scheduled_task.git","ref":"v5.0.0"}

--- a/packaging/configs/components/module-puppetlabs-selinux_core.json
+++ b/packaging/configs/components/module-puppetlabs-selinux_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-selinux_core.git","ref":"refs/tags/v1.4.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-selinux_core.git","ref":"refs/tags/v2.0.1"}

--- a/packaging/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/packaging/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-sshkeys_core.git","ref":"refs/tags/v2.5.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-sshkeys_core.git","ref":"refs/tags/v3.0.2"}

--- a/packaging/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/packaging/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-yumrepo_core.git","ref":"refs/tags/v2.1.0"}
+{"url":"https://github.com/openvoxproject/puppetlabs-yumrepo_core.git","ref":"refs/tags/v3.0.1"}

--- a/packaging/configs/components/module-puppetlabs-zfs_core.json
+++ b/packaging/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppetlabs-zfs_core.git","ref":"refs/tags/v1.6.1"}
+{"url":"https://github.com/openvoxproject/puppetlabs-zfs_core.git","ref":"refs/tags/v2.0.1"}


### PR DESCRIPTION
This updates all the modules to their latest versions. Only marked as backwards-incompatible because the rubocop linting got updated in those modules and they might not work with the older Ruby in the openvox 8 packages.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
