### PR TITLE
Remove setup.ps1 Cygwin setup script

### DIFF
--- a/packaging/setup.ps1
+++ b/packaging/setup.ps1
@@ -1,9 +1,0 @@
-$url="https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314.exe"
-$dest="C:\wix314.exe"
-Invoke-WebRequest -Uri $url -OutFile $dest
-cmd /c "C:\wix314.exe -quiet"
-
-$url="https://cygwin.com/setup-x86_64.exe"
-$dest="C:\setup-x86_64.exe"
-Invoke-WebRequest -Uri $url -OutFile $dest
-cmd /c "C:\setup-x86_64.exe -s https://cygwin.osuosl.org -q -P ruby=3.2.2-2,ruby-devel=3.2.2-2,gcc-core,make,git,libyaml-devel,libffi-devel"


### PR DESCRIPTION
### Short description

The logic in this script has been integrated into the shared-actions repository by PR OpenVoxProject/shared-actions#125 and the updated workflow no longer calls down to `setup.ps1`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
