### PR TITLE
puppet-runtime: update 2026.07.16.1->2026.08.04.1 / removed java keystores

### DIFF
--- a/packaging/configs/components/puppet-runtime.json
+++ b/packaging/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/2026.07.16.1/","version":"2026.07.16.1"}
+{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/2026.08.04.1/","version":"2026.08.04.1"}


### PR DESCRIPTION
**Component Changes:**
| Component | Old Version | New Version |
|-----------|-------------|-------------|
| puppet-ca-bundle-main | refs/tags/1.1.0  | refs/tags/1.2.0 | | rubygem-aws-partitions | 1.1268.0 | 1.1277.0 |
| rubygem-aws-sdk-ec2 | 1.632.0 | 1.633.0 |
| rubygem-concurrent-ruby | 1.3.7 | 1.3.8 |
| rubygem-excon | 1.5.0 | 1.6.0 |
| rubygem-yard | 0.9.44 | 0.9.45 |

The new ca bundle doesn't contain a java keystore anymore

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
