### PR TITLE
Migrate lookup acceptance tests to Hiera 5 data providers

### DIFF
--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -98,10 +98,21 @@ PP
   "project_page": null,
   "issues_url": null,
   "dependencies": [
-  ],
-  "data_provider": "function"
+  ]
 }
         ',
+        mode => "0644",
+      }
+      # Hiera 5 module layer: bind the module data function
+      # (replaces the removed metadata.json "data_provider" key)
+      file { '#{testdir}/environments/production/modules/#{module_name}/hiera.yaml':
+        ensure => file,
+        content => '---
+version: 5
+hierarchy:
+  - name: "Module data function"
+    v4_data_hash: #{module_name}::data
+',
         mode => "0644",
       }
       file { '#{testdir}/environments/production/modules/#{module_name}/lib/puppet/bindings':
@@ -202,11 +213,21 @@ file { '#{testdir}/environments/production/environment.conf':
   ensure => file,
   content => '
     environment_timeout = 0
-    # for this environment, provide our own function to supply data to lookup
-    # implies a ruby function in <environment>/lib/puppet/functions/environment/data.rb
-    #   named environment::data()
-    environment_data_provider = "function"
   ',
+  mode => "0640",
+}
+
+# Hiera 5 environment layer: bind the environment data function
+# (replaces the removed environment_data_provider setting; the function
+#  lives in <environment>/lib/puppet/functions/environment/data.rb)
+file { '#{testdir}/environments/production/hiera.yaml':
+  ensure => file,
+  content => '---
+version: 5
+hierarchy:
+  - name: "Environment data function"
+    v4_data_hash: environment::data
+',
   mode => "0640",
 }
 

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -354,7 +354,6 @@ file { '#{@coderoot}/environments/env1/environment.conf':
   ensure => file,
   mode => "0644",
   content => 'environment_timeout = 0
-environment_data_provider = "hiera"
 ',
 }
 
@@ -362,7 +361,6 @@ file { '#{@coderoot}/environments/env2/environment.conf':
   ensure => file,
   mode => "0644",
   content => 'environment_timeout = 0
-environment_data_provider = "function"
 ',
 }
 
@@ -370,7 +368,6 @@ file { '#{@coderoot}/environments/env3/environment.conf':
   ensure => file,
   mode => "0644",
   content => 'environment_timeout = 0
-environment_data_provider = "function"
 ',
 }
 
@@ -378,7 +375,6 @@ file { '#{@coderoot}/environments/env4/environment.conf':
   ensure => file,
   mode => "0644",
   content => 'environment_timeout = 0
-environment_data_provider = "none"
 ',
 }
 
@@ -422,7 +418,10 @@ file { '#{@coderoot}/environments/env2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Environment data function"
+      v4_data_hash: environment::data
 ',
 }
 
@@ -440,7 +439,10 @@ file { '#{@coderoot}/environments/env3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Environment data function"
+      v4_data_hash: environment::data
 ',
 }
 
@@ -458,7 +460,8 @@ file { '#{@coderoot}/environments/env4/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy: []
 ',
 }
 
@@ -629,7 +632,10 @@ file { '#{@coderoot}/environments/production/modules/mod2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod2::data
 ',
 }
 
@@ -648,7 +654,10 @@ file { '#{@coderoot}/environments/production/modules/mod3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod3::data
 ',
 }
 
@@ -660,14 +669,6 @@ file { '#{@coderoot}/environments/production/modules/mod3/data/common.yaml':
   "mod3::global_key": "module-production-mod3-hiera provided value"
   "environment_key": "module-production-mod3-hiera provided value"
   "global_key" => "module-production-mod3-hiera provided value"
-',
-}
-
-file { '#{@coderoot}/environments/production/modules/mod4/hiera.yaml':
-  ensure => file,
-  mode => "0644",
-  content => '---
-  version: 4
 ',
 }
 
@@ -704,7 +705,10 @@ file { '#{@coderoot}/environments/env1/modules/mod2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod2::data
 ',
 }
 
@@ -722,7 +726,10 @@ file { '#{@coderoot}/environments/env1/modules/mod3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod3::data
 ',
 }
 
@@ -733,14 +740,6 @@ file { '#{@coderoot}/environments/env1/modules/mod3/data/common.yaml':
   "mod3::module_key": "module-env1-mod3-hiera provided value"
   "global_key": "module-env1-mod3-hiera provided value"
   "environment_key": "module-env1-mod3-hiera provided value"
-',
-}
-
-file { '#{@coderoot}/environments/env1/modules/mod4/hiera.yaml':
-  ensure => file,
-  mode => "0644",
-  content => '---
-  version: 4
 ',
 }
 
@@ -776,7 +775,10 @@ file { '#{@coderoot}/environments/env2/modules/mod2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod2::data
 ',
 }
 
@@ -794,7 +796,10 @@ file { '#{@coderoot}/environments/env2/modules/mod3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod3::data
 ',
 }
 
@@ -805,14 +810,6 @@ file { '#{@coderoot}/environments/env2/modules/mod3/data/common.yaml':
   "mod3::module_key": "module-env2-mod3-hiera provided value"
   "global_key": "module-env2-mod3-hiera provided value"
   "environment_key": "module-env2-mod3-hiera provided value"
-',
-}
-
-file { '#{@coderoot}/environments/env2/modules/mod4/hiera.yaml':
-  ensure => file,
-  mode => "0644",
-  content => '---
-  version: 4
 ',
 }
 
@@ -848,7 +845,10 @@ file { '#{@coderoot}/environments/env3/modules/mod2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod2::data
 ',
 }
 
@@ -866,7 +866,10 @@ file { '#{@coderoot}/environments/env3/modules/mod3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod3::data
 ',
 }
 
@@ -877,14 +880,6 @@ file { '#{@coderoot}/environments/env3/modules/mod3/data/common.yaml':
   "mod3::module_key": "module-env3-mod3-hiera provided value"
   "global_key": "module-env3-mod3-hiera provided value"
   "environment_key": "module-env3-mod3-hiera provided value"
-',
-}
-
-file { '#{@coderoot}/environments/env3/modules/mod4/hiera.yaml':
-  ensure => file,
-  mode => "0644",
-  content => '---
-  version: 4
 ',
 }
 
@@ -920,7 +915,10 @@ file { '#{@coderoot}/environments/env4/modules/mod2/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod2::data
 ',
 }
 
@@ -938,7 +936,10 @@ file { '#{@coderoot}/environments/env4/modules/mod3/hiera.yaml':
   ensure => file,
   mode => "0644",
   content => '---
-  version: 4
+  version: 5
+  hierarchy:
+    - name: "Module data function"
+      v4_data_hash: mod3::data
 ',
 }
 
@@ -949,14 +950,6 @@ file { '#{@coderoot}/environments/env4/modules/mod3/data/common.yaml':
   "mod3::module_key": "module-env4-mod3-hiera provided value"
   "global_key": "module-env4-mod3-hiera provided value"
   "environment_key": "module-env4-mod3-hiera provided value"
-',
-}
-
-file { '#{@coderoot}/environments/env4/modules/mod4/hiera.yaml':
-  ensure => file,
-  mode => "0644",
-  content => '---
-  version: 4
 ',
 }
 
@@ -1712,8 +1705,7 @@ file { '#{@coderoot}/environments/production/modules/mod1/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }
 ',
 }
@@ -1730,8 +1722,7 @@ file { '#{@coderoot}/environments/production/modules/mod2/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1748,8 +1739,7 @@ file { '#{@coderoot}/environments/production/modules/mod3/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1766,8 +1756,7 @@ file { '#{@coderoot}/environments/production/modules/mod4/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "none"
+  "dependencies": []
 }
 ',
 }
@@ -1784,8 +1773,7 @@ file { '#{@coderoot}/environments/env1/modules/mod1/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }
 ',
 }
@@ -1802,8 +1790,7 @@ file { '#{@coderoot}/environments/env1/modules/mod2/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1820,8 +1807,7 @@ file { '#{@coderoot}/environments/env1/modules/mod3/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1838,8 +1824,7 @@ file { '#{@coderoot}/environments/env1/modules/mod4/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "none"
+  "dependencies": []
 }
 ',
 }
@@ -1856,8 +1841,7 @@ file { '#{@coderoot}/environments/env2/modules/mod1/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }
 ',
 }
@@ -1874,8 +1858,7 @@ file { '#{@coderoot}/environments/env2/modules/mod2/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1892,8 +1875,7 @@ file { '#{@coderoot}/environments/env2/modules/mod3/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1910,8 +1892,7 @@ file { '#{@coderoot}/environments/env2/modules/mod4/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "none"
+  "dependencies": []
 }
 ',
 }
@@ -1928,8 +1909,7 @@ file { '#{@coderoot}/environments/env3/modules/mod1/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }
 ',
 }
@@ -1946,8 +1926,7 @@ file { '#{@coderoot}/environments/env3/modules/mod2/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1964,8 +1943,7 @@ file { '#{@coderoot}/environments/env3/modules/mod3/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -1982,8 +1960,7 @@ file { '#{@coderoot}/environments/env3/modules/mod4/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "none"
+  "dependencies": []
 }
 ',
 }
@@ -2000,8 +1977,7 @@ file { '#{@coderoot}/environments/env4/modules/mod1/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }
 ',
 }
@@ -2018,8 +1994,7 @@ file { '#{@coderoot}/environments/env4/modules/mod2/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -2036,8 +2011,7 @@ file { '#{@coderoot}/environments/env4/modules/mod3/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "function"
+  "dependencies": []
 }
 ',
 }
@@ -2054,8 +2028,7 @@ file { '#{@coderoot}/environments/env4/modules/mod4/metadata.json':
   "source": "",
   "project_page": null,
   "issues_url": null,
-  "dependencies": [],
-  "data_provider": "none"
+  "dependencies": []
 }
 ',
 }
@@ -2498,7 +2471,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
   rxe4m1 = on(master, puppet('lookup', '--explain', '--environment env4', 'mod1::module_key'))
   result = rxe4m1.stdout
   assert_match(
-    /Global Data Provider.*\s*Using.*\s*Hier.*\s*Path.*\s*Orig.*\s*No such key.*\s*Module.*Data Provider.*\s*Using.*\s*Hier.*common\"\s*Path.*\s*Orig.*\s*Found key.*module-env4-mod1-hiera/,
+    /Global Data Provider.*\s*Using.*\s*Hier.*\s*Path.*\s*Orig.*\s*No such key.*\s*Environment Data Provider.*\s*Using.*\s*No such key.*\s*Module.*Data Provider.*\s*Using.*\s*Hier.*common\"\s*Path.*\s*Orig.*\s*Found key.*module-env4-mod1-hiera/,
     result,
     "environment env4 mod1::module_key lookup failed."
   )


### PR DESCRIPTION
### Short description
PRs #384/#385 removed the deprecated data_binding_terminus and environment_data_provider settings and the metadata.json data_provider key, as accepted in the OpenVox 9 deprecation review. Two acceptance tests still configured environment and module data through those removed mechanisms and began failing on all platforms once 9.0.0 beta packages were built (acceptance-pipelines run 31098859281).

Migrate the fixtures the same way #385 migrated the in-repo spec fixtures:

- tests/lookup/lookup.rb: bind the environment and module data functions through hiera.yaml (version 5, v4_data_hash) at the environment root and module roots; drop the data_provider key from metadata.json.

- tests/parser_functions/puppet_lookup_cmd.rb: env2/env3 (function providers) get env-level hiera.yaml v5 with v4_data_hash: environment::data; env4 (none) gets an explicit empty hierarchy, since environments always have a data layer under Hiera 5; production/env1 keep their still-supported v4 env hiera.yaml. mod2/mod3 (function) get module hiera.yaml v5 with v4_data_hash; mod4 (none) loses its hiera.yaml entirely so the module layer is absent, preserving the not-found behavior the assertions expect. The inert environment_data_provider lines and all 20 metadata.json data_provider keys are removed. One --explain assertion is updated because the environment data provider section now always appears in explain output (previously absent under provider none).

Verified on a local beaker rig (single almalinux 9 primary running openvox-agent 9.0.0~beta2 and openvox-server 9.0.0~beta4, the versions from the failing pipeline run): both pipeline failures reproduced exactly with the pristine tests, and both tests pass with this change. All lookup *value* expectations are unchanged -- the loader picks the same function implementations the v4 providers did (ruby when both ruby and puppet-language exist, e.g. env2/mod2; puppet-language when only it exists, e.g. env3/mod3) and the v4_data_hash backend even preserves the Deprecated API function explain wording the test asserts.

Note for rerunning on persistent hosts: the puppet_lookup_cmd teardown removes node1/node2 SSL keys but not the CA-signed certs, so back-to-back runs against the same CA need a puppetserver ca clean first. Fresh pipeline VMs are unaffected.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
