### PR TITLE
Compare facterversion against installed facter in acceptance test

### DIFF
--- a/packaging/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
+++ b/packaging/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
@@ -4,9 +4,14 @@ test_name 'Ensure puppet facts can use facter' do
 
   agents.each do |agent|
     step 'test puppet facts with correct facter version' do
+      # Compare against the installed facter rather than a hardcoded major
+      # version, which broke on every openfact major bump (4 -> 5 -> 6).
+      installed_version = on(agent, facter('--version'), :acceptable_exit_codes => [0]).stdout.strip
       on(agent, puppet('facts'), :acceptable_exit_codes => [0]) do |result|
-        facter_major_version =  Integer(JSON.parse(result.stdout)["facterversion"].split('.').first)
-        assert(5 >= facter_major_version, "wrong facter version")
+        facterversion = JSON.parse(result.stdout)["facterversion"]
+        assert_equal(installed_version, facterversion,
+                     "puppet facts reported facterversion #{facterversion.inspect}, " \
+                     "but the installed facter is #{installed_version.inspect}")
       end
     end
 


### PR DESCRIPTION
### Short description
ensure_puppet_facts_can_use_facter.rb asserted that the facterversion fact reported a major version of at most 5. Hardcoding the major version breaks on every openfact major bump -- openfact 6.0.0 shipped in openvox-agent 9.0.0~beta2 made the test fail on all 11 platforms in acceptance run 31098859281 (openvox-agent suite).

Compare the fact against the output of facter --version on the agent instead, which expresses what the test actually cares about (puppet facts uses the bundled facter) and survives future major bumps.

Verified on a local beaker rig against openvox-agent 9.0.0~beta2 (openfact 6.0.0): the unmodified test fails with the same Minitest assertion as the pipeline; with this change it passes.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
