### PR TITLE
Request report storage explicitly in cached-catalog drift test

### DIFF
--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -14,10 +14,17 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
 
   basedir = master.tmpdir(File.basename(__FILE__, '.*'))
   module_dir = "#{basedir}/environments/production/modules"
+  master_reportdir = create_tmpdir_for_user(master, 'reportdir')
 
   master_opts = {
    'main' => {
       'environmentpath' => "#{basedir}/environments"
+    },
+   # The server no longer stores reports by default (reports = none);
+   # request storage explicitly like the other report-checking tests do.
+   'master' => {
+      'reportdir' => master_reportdir,
+      'reports' => 'store'
     }
   }
 
@@ -28,6 +35,7 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
   teardown do
     cleanup_puppetserver_code_id_scripts(master, basedir)
     on master, "rm -rf #{basedir}"
+    on master, "rm -rf #{master_reportdir}"
 
     agents.each do |agent|
       on(agent, puppet('config print lastrunfile')) do |command_result|
@@ -96,9 +104,9 @@ MANIFEST
       # sends a report.
 
       step "Remove existing reports from server reports directory"
-      on(master, "rm -rf /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name}/*")
-      r = on(master, "ls /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name} | wc -l").stdout.chomp
-      assert_equal(r, '0', "reports directory should be empty!")
+      on(master, "rm -rf #{master_reportdir}/#{agent.node_name}/*")
+      r = on(master, "ls #{master_reportdir}/#{agent.node_name} 2>/dev/null | wc -l").stdout.chomp
+      assert_equal('0', r, "reports directory should be empty!")
 
       step "Verify puppet run without drift does not make file request from server"
       r = on(agent, puppet("agent",
@@ -113,8 +121,8 @@ MANIFEST
       assert_equal(r, "", "Fail: Did agent try to contact server?")
 
       step "Verify report was delivered to server"
-      r = on(master, "ls /opt/puppetlabs/server/data/puppetserver/reports/#{agent.node_name} | wc -l").stdout.chomp
-      assert_equal(r, '1', "Reports directory should have one file")
+      r = on(master, "ls #{master_reportdir}/#{agent.node_name} | wc -l").stdout.chomp
+      assert_equal('1', r, "Reports directory should have one file")
 
       step "agent: #{agent}: Remove the test file to simulate drift"
       on(agent, "rm -rf #{agent_test_file_path}")


### PR DESCRIPTION
### Short description
#583 changed the default of the reports setting from `store` to `none`, so the server now accepts report submissions and hands them to no processors. `cached_catalog_remediate_local_drift.rb` asserted that a submitted report appears under the server `reportdir` while relying on the old default, and began failing on all platforms in acceptance run [31098859281](https://github.com/OpenVoxProject/acceptance-pipelines/actions/runs/31098859281) (`openvox` suite, `shard:group4`). Diagnosis on a local rig confirmed the agent PUT succeeds (200 in the server access log) while nothing is stored.

Set `reports = store` and a test-owned `reportdir` in `master_opts`, matching the pattern the other report-checking acceptance tests (`reports/submission.rb`, `reports/cached_catalog_status_in_report.rb`, `direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb`) already use -- this test was the only one relying on the default. Also fix the reversed `assert_equal argument` order in the two report-count assertions so failure messages report expected and actual correctly, and clean up the `reportdir` in teardown.

Verified on a local beaker rig against openvox-agent `9.0.0~beta2` and openvox-server `9.0.0~beta4`: the unmodified test reproduces the pipeline failure; with this change it passes.

Note for release notes: the `reports=none` default change itself is user-visible (report YAML consumers must now set `reports=store`) and should be called out in the 9.0 release notes.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
