### PR TITLE
Update filebucket content acceptance tests for literal checksum semantics

### DIFF
--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -46,34 +46,9 @@ agents.each do |agent|
   step "Ensure the test environment is clean"
   on(agent, "rm -f #{target}")
 
-  step "Content Attribute: using a checksum from filebucket"
-  on(agent, "echo 'This is the checksum file contents' > #{target}")
-
-  step "Backup file into the filebucket"
-  on(agent, puppet_filebucket("backup --local #{target}"))
-
-  step "Modify file to force apply to retrieve file from local clientbucket"
-  on(agent, "echo 'This is the modified file contents' > #{target}")
-
-  dir = agent.puppet('user')['clientbucketdir']
-
-  sha256_manifest = %Q|
-    filebucket { 'local':
-      path => '#{dir}',
-    }
-
-    file { '#{target}':
-      ensure  => present,
-      content => '{sha256}3b9238769b033b48073267b8baea00fa51c598dc14081da51f2e510c37c46a28',
-      backup  => local,
-    }
-  |
-
-  step "Applying Manifest on Agent"
-  apply_manifest_on agent, sha256_manifest
-
-  step "Validate filebucket checksum file contents"
-  on(agent, "cat #{target}") do |result|
-    assert_match(/This is the checksum file content/, result.stdout, "File content not matched on #{agent}") unless agent['locale'] == 'ja'
-  end
+  # The "checksum from filebucket" scenario was removed along with the
+  # implicit filebucket retrieval for checksum-like content values
+  # (openvox#170); content is now always managed literally. See
+  # ticket_6541_invalid_filebucket_files.rb for coverage of the literal
+  # behavior.
 end

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,42 +1,40 @@
-test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
+test_name "#6541: checksum-like file content is managed literally" do
 
 tag 'audit:high',
     'audit:integration', # file type and file bucket interop
-    'audit:refactor',    # look into combining with ticket_4622_filebucket_diff_test.rb
-                         # Use block style `test_run`
     'shard:group3' # For splitting out groups of tests for slow test runners
 
-agents.each do |agent|
-  target=agent.tmpfile('6541-target')
+  # Historically, a content value that looked like a checksum
+  # ('{sha256}...', '{md5}...') triggered implicit filebucket retrieval,
+  # which made it impossible to manage a file whose literal content looks
+  # like a checksum, and truncated the target when the bucket could not
+  # supply the hash (the original #6541). That behavior was removed in
+  # OpenVox 9 (openvox#170): content is now always literal.
 
-  on(agent, "rm -rf \"#{agent.puppet['vardir']}/*bucket\"")
+  agents.each do |agent|
+    target = agent.tmpfile('6541-target')
 
-  step "write zero length file"
-  manifest = "file { '#{target}': content => '' }"
-  apply_manifest_on(agent, manifest)
+    step "write initial file content" do
+      manifest = "file { '#{target}': content => 'some text' }"
+      apply_manifest_on(agent, manifest)
+    end
 
-  step "overwrite file, causing zero-length file to be backed up"
-  manifest = "file { '#{target}': content => 'some text', backup => 'puppet' }"
-  apply_manifest_on(agent, manifest)
+    step "checksum-like content that is not a valid hash is written literally" do
+      manifest = "file { '#{target}': content => '{sha256}notahash' }"
+      apply_manifest_on(agent, manifest)
+      on(agent, "cat #{target}") do |result|
+        assert_equal('{sha256}notahash', result.stdout, "#{agent}: expected the literal content to be written")
+      end
+    end
 
-  test_name "verify invalid hashes should not change the file"
-
-  manifest = "file { '#{target}': content => '{sha256}notahash' }"
-
-  apply_manifest_on(agent, manifest) do |result|
-    refute_match(/content changed/, result.stdout, "#{agent}: shouldn't have overwrote the file")
-  end
-
-  test_name "verify valid but unbucketed hashes should not change the file"
-  manifest = "file { '#{target}': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
-  apply_manifest_on(agent, manifest) do |result|
-    refute_match(/content changed/, result.stdout, "#{agent}: shouldn't have overwrote the file")
-  end
-
-  test_name "verify that an empty file can be retrieved from the filebucket"
-  manifest = "file { '#{target}': content => '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', backup => 'puppet' }"
-
-  apply_manifest_on(agent, manifest) do |result|
-    assert_match(/content changed '\{sha256\}b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2' to '\{sha256\}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'/, result.stdout, "#{agent}: shouldn't have overwrote the file")
+    step "well-formed checksum content is also written literally, not resolved from a bucket" do
+      manifest = "file { '#{target}': content => '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', backup => 'puppet' }"
+      apply_manifest_on(agent, manifest)
+      on(agent, "cat #{target}") do |result|
+        assert_equal('{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                     result.stdout,
+                     "#{agent}: expected the literal checksum string, not filebucket content")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Short description
#170 removed the implicit filebucket retrieval for file content values that look like checksums; such content is now always managed literally. Two acceptance tests still exercised the removed behavior and fail on all platforms ([acceptance run 31157133263](https://github.com/OpenVoxProject/acceptance-pipelines/actions/runs/31157133263), openvox suite `shard:group3`; also present but masked behind the lookup failures in run [31098859281](https://github.com/OpenVoxProject/acceptance-pipelines/actions/runs/31098859281)):

- `ticket_6541_invalid_filebucket_files.rb` asserted that checksum-like content never overwrites the target and that a well-formed checksum retrieves bucket content. Rewritten as a regression test for the new semantics: checksum-like content -- malformed or well-formed -- is written literally, which is exactly the capability whose absence motivated the removal.

- `resource/file/content_attribute.rb` ended with a checksum-from-filebucket scenario; that block is removed with a comment pointing at the rewritten test. The raw-content, checksum-type, and illegal-timestamp coverage is unchanged.

Verified on a local beaker rig against openvox-agent `9.0.0~beta2`: both tests reproduce the pipeline failures unmodified and pass with this change.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
