### PR TITLE
Fix user provider specs

### DIFF
--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -62,19 +62,19 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
 
     it "should return the loginclass if set", :if => Puppet.features.libshadow? do
       expect(Shadow::Passwd).to receive(:getspnam).with('myuser').and_return(shadow_entry)
-      provider.send(:loginclass).should == 'staff'
+      expect(provider.send(:loginclass)).to eq('staff')
     end
 
     it "should return the empty string when loginclass isn't set", :if => Puppet.features.libshadow? do
       shadow_entry[:sp_loginclass] = ''
       expect(Shadow::Passwd).to receive(:getspnam).with('myuser').and_return(shadow_entry)
-      provider.send(:loginclass).should == ''
+      expect(provider.send(:loginclass)).to eq('')
     end
 
     it "should return nil when loginclass isn't available", :if => Puppet.features.libshadow? do
       shadow_entry[:sp_loginclass] = nil
       expect(Shadow::Passwd).to receive(:getspnam).with('myuser').and_return(shadow_entry)
-      provider.send(:loginclass).should be_nil
+      expect(provider.send(:loginclass)).to be_nil
     end
   end
 end

--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
 
   let(:shadow_entry) {
     return unless Puppet.features.libshadow?
-    entry = Etc::PasswdEntry.new
+    entry = Shadow::Passwd::Entry.new
     entry[:sp_namp]   = 'myuser' # login name
     entry[:sp_loginclass] = 'staff' # login class
     entry
@@ -47,7 +47,11 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
       allow(Facter).to receive(:value).with('os.family').and_return('OpenBSD')
       allow(Facter).to receive(:value).with('os.release.major')
       resource[:expiry] = "1997-06-01"
-      expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', 'June 01 1997', 'myuser'])
+      if Puppet.features.libshadow?
+        expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', 'June 01 1997', '-L', 'staff', 'myuser'])
+      else
+        expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', 'June 01 1997', 'myuser'])
+      end
     end
   end
 

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
   let(:shadow_entry) {
     return unless Puppet.features.libshadow?
-    entry = Etc::PasswdEntry.new
+    entry = Shadow::Passwd::Entry.new
     entry[:sp_namp]   = 'myuser' # login name
     entry[:sp_pwdp]   = '$6$FvW8Ib8h$qQMI/CR9m.QzIicZKutLpBgCBBdrch1IX0rTnxuI32K1pD9.RXZrmeKQlaC.RzODNuoUtPPIyQDufunvLOQWF0' # encrypted password
     entry[:sp_lstchg] = 15573    # date of last password change
@@ -675,7 +675,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
   {
     :password_min_age   => 10,
     :password_max_age   => 20,
-    :password_warn_days => 30,
+    :password_warn_days => 7,
     :password           => '$6$FvW8Ib8h$qQMI/CR9m.QzIicZKutLpBgCBBdrch1IX0rTnxuI32K1pD9.RXZrmeKQlaC.RzODNuoUtPPIyQDufunvLOQWF0'
   }.each_pair do |property, expected_value|
     describe "##{property}" do


### PR DESCRIPTION
This fixes multiple user provider specs failing with:

  NameError:
    uninitialized constant Etc::PasswdEntry

which suggests these specs weren't getting much exercise, probably because the CI environment is lacking the ruby-shadow library which in turn disables the Puppet feature transparently.

It also updates a couple assertions that were also outdated.