### PR TITLE
Report errors when renewing a certificate fails

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -304,13 +304,14 @@ class Puppet::Application::Ssl < Puppet::Application
     @cert_provider.delete_request(certname)
     cert
   rescue Puppet::HTTP::ResponseError => e
-    if e.response.code == 404
-      nil
-    else
-      raise Puppet::Error.new(_("Failed to download certificate: %{message}") % { message: e.message }, e)
-    end
+    body = e.response.body.to_s.strip
+    raise Puppet::Error.new(_("Failed to renew certificate: %{code} %{reason}%{body}") % {
+      code: e.response.code,
+      reason: e.response.reason,
+      body: body.empty? ? '' : ": #{body}"
+    }, e)
   rescue => e
-    raise Puppet::Error.new(_("Failed to download certificate: %{message}") % { message: e.message }, e)
+    raise Puppet::Error.new(_("Failed to renew certificate: %{message}") % { message: e.message }, e)
   end
 
   def verify(certname)

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -320,8 +320,14 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       stub_request(:post, %r{puppet-ca/v1/certificate_renewal}).to_return(status: 200, body: renewed[:cert].to_pem)
 
       expects_command_to_fail(
-        %r{^Failed to download certificate: The certificate for 'CN=ssl-client' does not match its private key}
+        %r{^Failed to renew certificate: The certificate for 'CN=ssl-client' does not match its private key}
       )
+    end
+
+    it 'raises an error if the CA returns an error response' do
+      stub_request(:post, %r{puppet-ca/v1/certificate_renewal}).to_return(status: [404, 'Not Found'], body: 'Certificate was not found')
+
+      expects_command_to_fail(%r{^Failed to renew certificate: 404 Not Found: Certificate was not found})
     end
   end
   


### PR DESCRIPTION
### Short description

When the CA returned an error (e.g. 404) while renewing a certificate, renew_cert swallowed the response and returned nil, so `puppet ssl renew_cert` exited successfully without renewing anything. Now the command raises a Puppet::Error that includes the HTTP code, reason, and response body so users can see the renewal failed.

Fixes #605 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
