### PR TITLE
puppet generate: print module directory when types are missing

### DIFF
--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -124,7 +124,7 @@ module Puppet
         environment.modules.each do |mod|
           directory = File.join(Puppet::Util::Autoload.cleanpath(mod.plugin_directory), 'puppet', 'type')
           unless Puppet::FileSystem.exist?(directory)
-            Puppet.debug "Skipping '#{mod.name}' module because it contains no custom types."
+            Puppet.debug "Skipping '#{mod.name}' module because there is no readable puppet/type/ directory under: #{directory}"
             next
           end
 


### PR DESCRIPTION
### Short description

When `puppet generate types` is run, it scans the `modulepath` in an environment and compiles environment-isolated implementations for each module that contains a `puppet/type/` sub-directory. When run with debug logging enabled, the command prints the name of each module skipped due to the types sub-directory not being visible.

This commit updates the debug-level message to add the path to the module directory that was examined. Module discovery is done by walking the `modulepath`, which is a prioritized list of locations that modules can be loaded from. Including the directory path in the debug message gives users a signal that can indicate when a module has been shadowed by another directory with the same name, but higher precedence on the `modulepath`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
